### PR TITLE
MMC5: overhaul mapper implementation and add expansion audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 build*/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.vscode
+/.*/
 build*/
-.idea

--- a/cmake/CMakeRC.cmake
+++ b/cmake/CMakeRC.cmake
@@ -34,7 +34,7 @@ endif()
 
 set(_version 2.0.0)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 include(CMakeParseArguments)
 
 if(COMMAND cmrc_add_resource_library)

--- a/src/GeraNES/APU/APU.h
+++ b/src/GeraNES/APU/APU.h
@@ -102,7 +102,16 @@ public:
         write(0x0017, 0x00);
         for(int i = 0; i < 12; i++ ) cycle();
 
+        // Mapper expansion audio is fed at CPU-cycle rate.
+        m_audioOutput.setExpansionAudioSampleRate(static_cast<float>(m_settings.CPUClockHz()));
+        m_audioOutput.setExpansionAudioVolume(1.0f);
+
         return "";
+    }
+
+    GERANES_INLINE void addExpansionAudioSample(float sample)
+    {
+        m_audioOutput.addExpansionAudioSample(sample);
     }
 
     GERANES_INLINE_HOT bool getInterruptFlag()
@@ -209,6 +218,9 @@ public:
 
     void updateAudioOutput()
     {
+        m_audioOutput.setExpansionAudioSampleRate(static_cast<float>(m_settings.CPUClockHz()));
+        m_audioOutput.setExpansionAudioVolume(1.0f);
+
         switch(m_pulse1.getDuty())
         {
         case 0: m_audioOutput.setPulseDutyCycle(IAudioOutput::PulseChannel::Pulse_1, 0.125f); break;

--- a/src/GeraNES/CPU2A03.h
+++ b/src/GeraNES/CPU2A03.h
@@ -1347,6 +1347,7 @@ inline void CPU2A03::endCycle() {
 
     if(!m_console.ppu().inOverclockLines()) {       
         m_console.cartridge().cycle();
+        m_console.apu().addExpansionAudioSample(m_console.cartridge().getExpansionAudioSample());
     }       
 
     m_console.ppu().ppuCyclePAL(); 

--- a/src/GeraNES/Cartridge.h
+++ b/src/GeraNES/Cartridge.h
@@ -344,11 +344,6 @@ public:
         m_mapper->setSpriteSize8x16(sprite8x16);
     }
 
-    GERANES_INLINE void setPpuReadAffectsBus(bool affectsBus)
-    {
-        m_mapper->setPpuReadAffectsBus(affectsBus);
-    }
-
     GERANES_INLINE void setPpuMask(uint8_t mask)
     {
         m_mapper->setPpuMask(mask);

--- a/src/GeraNES/Cartridge.h
+++ b/src/GeraNES/Cartridge.h
@@ -17,6 +17,7 @@
 
 #include "Mappers/Mapper004.h"
 #include "Mappers/Mapper004_3.h"
+#include "Mappers/Mapper005.h"
 
 #include "Mappers/Mapper007.h"
 #include "Mappers/Mapper009.h"
@@ -316,6 +317,61 @@ public:
     GERANES_INLINE_HOT uint8_t readCustomNameTable(uint8_t index, uint16_t addr)
     {
         return m_mapper->readCustomNameTable(index,addr);
+    }
+
+    GERANES_INLINE_HOT void writeCustomNameTable(uint8_t index, uint16_t addr, uint8_t data)
+    {
+        m_mapper->writeCustomNameTable(index,addr,data);
+    }
+
+    GERANES_INLINE void onScanlineStart(bool renderingEnabled, int scanline)
+    {
+        m_mapper->onScanlineStart(renderingEnabled, scanline);
+    }
+
+    GERANES_INLINE void setPpuFetchSource(bool isSpriteFetch)
+    {
+        m_mapper->setPpuFetchSource(isSpriteFetch);
+    }
+
+    GERANES_INLINE uint8_t transformNameTableRead(uint8_t index, uint16_t addr, uint8_t value)
+    {
+        return m_mapper->transformNameTableRead(index, addr, value);
+    }
+
+    GERANES_INLINE void setSpriteSize8x16(bool sprite8x16)
+    {
+        m_mapper->setSpriteSize8x16(sprite8x16);
+    }
+
+    GERANES_INLINE void setPpuReadAffectsBus(bool affectsBus)
+    {
+        m_mapper->setPpuReadAffectsBus(affectsBus);
+    }
+
+    GERANES_INLINE void setPpuMask(uint8_t mask)
+    {
+        m_mapper->setPpuMask(mask);
+    }
+
+    GERANES_INLINE void onPpuStatusRead(bool vblankSet)
+    {
+        m_mapper->onPpuStatusRead(vblankSet);
+    }
+
+    GERANES_INLINE void onPpuRead(uint16_t addr)
+    {
+        m_mapper->onPpuRead(addr);
+    }
+
+    GERANES_INLINE void onPpuCycle(int scanline, int cycle, bool isRendering, bool isPreLine)
+    {
+        m_mapper->onPpuCycle(scanline, cycle, isRendering, isPreLine);
+    }
+
+    GERANES_INLINE void onCpuRead(uint16_t addr)
+    {
+        m_mapper->onCpuRead(addr);
     }
 
     GERANES_INLINE GameDatabase::Sistem system()

--- a/src/GeraNES/Cartridge.h
+++ b/src/GeraNES/Cartridge.h
@@ -374,6 +374,11 @@ public:
         m_mapper->onCpuRead(addr);
     }
 
+    GERANES_INLINE float getExpansionAudioSample()
+    {
+        return m_mapper->getExpansionAudioSample();
+    }
+
     GERANES_INLINE GameDatabase::Sistem system()
     {
         return m_nesCartridgeData->sistem();

--- a/src/GeraNES/GameDatabase.h
+++ b/src/GeraNES/GameDatabase.h
@@ -163,7 +163,7 @@ public:
         int SaveRamSize;
         Battery HasBattery;
         MirroringType Mirroring;
-        InputType InputType;
+        InputType InputDeviceType;
         BusConflictType BusConflicts;
         int SubmapperId;
         VsSystemType VsType;
@@ -365,7 +365,7 @@ private:
                 data.SaveRamSize = getInt(rawData.SaveRamSize);
                 data.HasBattery = getBattery(rawData.HasBattery);
                 data.Mirroring = getMirroringType(rawData.Mirroring);
-                data.InputType = getInputType(rawData.InputType);
+                data.InputDeviceType = getInputType(rawData.InputType);
                 data.BusConflicts = getBusConflictType(rawData.BusConflicts);
                 data.SubmapperId = getInt(rawData.SubMapperId);
                 data.VsType = getVsSystemType(rawData.VsSystemType);

--- a/src/GeraNES/GeraNESEmu.h
+++ b/src/GeraNES/GeraNESEmu.h
@@ -181,7 +181,10 @@ private:
 
         default: // >= 8
             if constexpr(writeFlag) m_cartridge.writePrg(addr&0x7FFF, data);
-            else data = m_cartridge.readPrg(addr&0x7FFF);
+            else {
+                m_cartridge.onCpuRead(static_cast<uint16_t>(addr));
+                data = m_cartridge.readPrg(addr&0x7FFF);
+            }
             break;
 
         }
@@ -216,6 +219,7 @@ private:
     {
         m_zapper1.onScanlineChanged();
         m_zapper2.onScanlineChanged();
+        m_cartridge.onScanlineStart(m_ppu.isActivelyRendering(), m_ppu.scanline());
     }
 
     void onDMCRequest(uint16_t addr, bool reload) {

--- a/src/GeraNES/IAudioOutput.h
+++ b/src/GeraNES/IAudioOutput.h
@@ -19,6 +19,9 @@ class IAudioOutput
     virtual void setNoiseMetallic(bool /*state*/){}
     virtual void addSample(float /*sample*/){}
     virtual void addSampleDirect(float /*period*/, float /*sample*/){}
+    virtual void setExpansionAudioSampleRate(float /*rateHz*/) {}
+    virtual void setExpansionAudioVolume(float /*volume*/) {}
+    virtual void addExpansionAudioSample(float /*sample*/) {}
 
     virtual ~IAudioOutput(){}
 };

--- a/src/GeraNES/Mappers/BaseMapper.h
+++ b/src/GeraNES/Mappers/BaseMapper.h
@@ -182,10 +182,6 @@ public:
     {
     }
 
-    virtual void setPpuReadAffectsBus(bool /*affectsBus*/)
-    {
-    }
-
     virtual void setPpuMask(uint8_t /*mask*/)
     {
     }

--- a/src/GeraNES/Mappers/BaseMapper.h
+++ b/src/GeraNES/Mappers/BaseMapper.h
@@ -206,6 +206,11 @@ public:
     {
     }
 
+    virtual float getExpansionAudioSample()
+    {
+        return 0.0f;
+    }
+
     virtual ~BaseMapper()
     {
         writeSaveRamToFile();

--- a/src/GeraNES/Mappers/BaseMapper.h
+++ b/src/GeraNES/Mappers/BaseMapper.h
@@ -132,6 +132,8 @@ public:
 
     virtual uint8_t readCustomNameTable(uint8_t index, uint16_t addr) { return 0; }
 
+    virtual void writeCustomNameTable(uint8_t /*index*/, uint16_t /*addr*/, uint8_t /*data*/) {}
+
     virtual void writeSaveRam(int addr, uint8_t data)
     {
         if(m_sRam != nullptr)
@@ -157,6 +159,51 @@ public:
     virtual uint8_t customMirroring(uint8_t /*blockIndex*/)
     {
         return 0;
+    }
+
+    virtual void onScanlineStart(bool /*renderingEnabled*/)
+    {
+    }
+    virtual void onScanlineStart(bool renderingEnabled, int /*scanline*/)
+    {
+        onScanlineStart(renderingEnabled);
+    }
+
+    virtual void setPpuFetchSource(bool /*isSpriteFetch*/)
+    {
+    }
+
+    virtual uint8_t transformNameTableRead(uint8_t /*index*/, uint16_t /*addr*/, uint8_t value)
+    {
+        return value;
+    }
+
+    virtual void setSpriteSize8x16(bool /*sprite8x16*/)
+    {
+    }
+
+    virtual void setPpuReadAffectsBus(bool /*affectsBus*/)
+    {
+    }
+
+    virtual void setPpuMask(uint8_t /*mask*/)
+    {
+    }
+
+    virtual void onPpuStatusRead(bool /*vblankSet*/)
+    {
+    }
+
+    virtual void onPpuRead(uint16_t /*addr*/)
+    {
+    }
+
+    virtual void onPpuCycle(int /*scanline*/, int /*cycle*/, bool /*isRendering*/, bool /*isPreLine*/)
+    {
+    }
+
+    virtual void onCpuRead(uint16_t /*addr*/)
+    {
     }
 
     virtual ~BaseMapper()
@@ -194,7 +241,7 @@ public:
         }
     }
 
-    GERANES_INLINE bool hasChrRam() {
+    GERANES_INLINE bool hasChrRam() const {
         return m_cd.chrRamSize() > 0;
     }
 

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -1,0 +1,1116 @@
+#pragma once
+
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+
+#include "BaseMapper.h"
+
+// MMC5
+// Implemented features in this mapper:
+// - PRG banking modes ($5100, $5113-$5117)
+// - CHR banking modes ($5101, $5120-$512B, $5130)
+// - Extended nametable mapping (CIRAM/ExRAM/fill) ($5104-$5107)
+// - Scanline IRQ core registers ($5203/$5204)
+// - 8x8 multiplier ($5205/$5206)
+//
+// Not implemented in this mapper:
+// - Expansion audio
+class Mapper005 : public BaseMapper
+{
+private:
+    uint8_t m_prgMode = 3;
+    uint8_t m_chrMode = 3;
+    uint8_t m_chrModeByte = 3;
+    bool m_chrRamEnable = false;
+
+    uint8_t m_exRamMode = 0;
+
+    uint8_t m_prgRamProtect1 = 0;
+    uint8_t m_prgRamProtect2 = 0;
+
+    uint8_t m_nameTableMap[4] = {0, 0, 0, 0};
+
+    uint8_t m_fillTile = 0;
+    uint8_t m_fillAttribute = 0;
+
+    uint8_t m_prgRamBank6000 = 0;
+
+    uint8_t m_prgRegs[4] = {0x80, 0x80, 0x80, 0xFF};
+
+    uint16_t m_chrSpriteRegs[8] = {0};
+    uint16_t m_chrBgRegs[4] = {0};
+    uint16_t m_chrMapA[8] = {0};
+    uint16_t m_chrMapB[8] = {0};
+    uint8_t m_chrUpperBits = 0;
+    uint8_t m_abMode = 0;
+
+    uint8_t m_irqScanline = 0;
+    bool m_irqEnable = false;
+    bool m_irqPending = false;
+    bool m_inFrame = false;
+    uint8_t m_irqCounter = 0;
+    uint8_t m_matchCount = 0;
+    bool m_ppuReading = false;
+    uint16_t m_ppuReadAddress = 0;
+    uint16_t m_lastPpuReadAddress = 0xFFFF;
+    uint8_t m_idleCount = 0;
+
+    uint8_t m_mulA = 0xFF;
+    uint8_t m_mulB = 0xFF;
+    uint8_t m_audioPulseRegs[2][4] = {{0}, {0}};
+    uint8_t m_audioPcmControl = 0;
+    uint8_t m_audioPcmValue = 0;
+    uint8_t m_audioStatus = 0;
+    uint8_t m_mmc5aRegs[2] = {0}; // $5207/$5208
+    uint16_t m_mmc5aTimerCounter = 0; // $5209/$520A
+    bool m_mmc5aTimerActive = false;
+    bool m_mmc5aTimerIrqFlag = false;
+
+    uint8_t m_prgRom8kMask = 0;
+    uint16_t m_chrRom1kMask = 0;
+    uint16_t m_chrRam1kMask = 0;
+    uint16_t m_chr1kMask = 0;
+    bool m_isSpriteFetch = false;
+    bool m_sprite8x16 = false;
+    bool m_renderingEnabled = false;
+    bool m_substitutionsEnabled = false;
+    uint8_t m_extAttrLatch = 0;
+    uint8_t m_splitAttrLatch = 0;
+    uint8_t m_splitMode = 0;
+    uint8_t m_splitScroll = 0;
+    uint8_t m_splitBank = 0;
+    uint8_t m_splitVScroll = 0;
+    bool m_splitActive = false;
+    uint8_t m_splitTileCount = 0;
+    uint8_t m_splitScanline = 0;
+    int m_curTile = -1;
+    int16_t m_lineCounter = -2;
+    uint16_t m_lastNtRead = 0xFFFF;
+    uint8_t m_sameNtReadCount = 0;
+    bool m_lastSplitActiveLogged = false;
+    bool m_lastSplitStateValid = false;
+    uint16_t m_lastLoggedChrBank = 0xFFFF;
+    uint8_t m_lastLoggedChrPage = 0xFF;
+    bool m_traceInitDone = false;
+    bool m_traceEnabled = false;
+    bool m_traceChr = false;
+    uint32_t m_traceLines = 0;
+    std::ofstream m_traceFile;
+    static constexpr uint32_t TRACE_MAX_LINES = 200000;
+
+    std::array<uint8_t, 0x400> m_exRam = {};
+    std::array<uint8_t, 0x400> m_mmc5aRam = {};
+    std::array<uint8_t, 0x10000> m_prgRam = {};
+
+    GERANES_INLINE uint16_t calculateMask16(int nBanks) const
+    {
+        uint16_t mask = 0;
+        int n = nBanks - 1;
+        while(n > 0) {
+            mask = static_cast<uint16_t>((mask << 1) | 1);
+            n >>= 1;
+        }
+        return mask;
+    }
+
+    void initTraceIfNeeded()
+    {
+        if(m_traceInitDone) {
+            return;
+        }
+        m_traceInitDone = true;
+
+        const char* enabled = std::getenv("GERANES_MMC5_TRACE");
+        if(enabled == nullptr || enabled[0] == '0') {
+            return;
+        }
+
+        const char* path = std::getenv("GERANES_MMC5_TRACE_FILE");
+        if(path == nullptr || path[0] == '\0') {
+            path = "/tmp/geranes-mmc5-trace.log";
+        }
+
+        m_traceFile.open(path, std::ios::out | std::ios::trunc);
+        m_traceEnabled = m_traceFile.is_open();
+        const char* traceChr = std::getenv("GERANES_MMC5_TRACE_CHR");
+        m_traceChr = (traceChr != nullptr && traceChr[0] != '0');
+
+        if(m_traceEnabled) {
+            m_traceFile << "MMC5 trace start\n";
+            m_traceFile.flush();
+        }
+    }
+
+    void traceLine(const std::string& s)
+    {
+        initTraceIfNeeded();
+        if(!m_traceEnabled || m_traceLines >= TRACE_MAX_LINES) {
+            return;
+        }
+        m_traceFile << s << '\n';
+        ++m_traceLines;
+        if((m_traceLines & 0x3FF) == 0) {
+            m_traceFile.flush();
+        }
+    }
+
+    GERANES_INLINE uint8_t fillAttributeByte() const
+    {
+        uint8_t v = m_fillAttribute & 0x03;
+        return static_cast<uint8_t>(v | (v << 2) | (v << 4) | (v << 6));
+    }
+
+    GERANES_INLINE static uint8_t expandPaletteBits(uint8_t p)
+    {
+        p &= 0x03;
+        return static_cast<uint8_t>(p | (p << 2) | (p << 4) | (p << 6));
+    }
+
+    GERANES_INLINE bool prgRamWriteEnabled() const
+    {
+        return (m_prgRamProtect1 & 0x03) == 0x02 && (m_prgRamProtect2 & 0x03) == 0x01;
+    }
+
+    GERANES_INLINE uint8_t readPrgRam8k(uint8_t bank8k, int addr)
+    {
+        uint8_t bank = bank8k & 0x07;
+        return m_prgRam[(bank << log2(BankSize::B8K)) + (addr & (static_cast<int>(BankSize::B8K) - 1))];
+    }
+
+    GERANES_INLINE void writePrgRam8k(uint8_t bank8k, int addr, uint8_t data)
+    {
+        if(!prgRamWriteEnabled()) {
+            return;
+        }
+
+        uint8_t bank = bank8k & 0x07;
+        m_prgRam[(bank << log2(BankSize::B8K)) + (addr & (static_cast<int>(BankSize::B8K) - 1))] = data;
+    }
+
+    GERANES_INLINE uint8_t readPrgRom8k(uint8_t bank8k, int addr)
+    {
+        return m_cd.readPrg<BankSize::B8K>(bank8k & m_prgRom8kMask, addr);
+    }
+
+    struct PrgWindow {
+        bool ram = false;
+        bool writable = false;
+        uint8_t bank8k = 0;
+    };
+
+    GERANES_INLINE PrgWindow resolvePrgWindow(int addr)
+    {
+        PrgWindow w;
+
+        uint8_t slot = static_cast<uint8_t>((addr >> 13) & 0x03);
+
+        auto decode8k = [&](uint8_t reg, bool forceRom) {
+            w.ram = !forceRom && ((reg & 0x80) == 0);
+            w.writable = w.ram;
+            w.bank8k = reg & 0x7F;
+        };
+
+        auto decode16k = [&](uint8_t reg, uint8_t half, bool forceRom) {
+            w.ram = !forceRom && ((reg & 0x80) == 0);
+            w.writable = w.ram;
+            // In 16K modes, register bit 0 is ignored and CPU A13 selects the 8K half.
+            w.bank8k = static_cast<uint8_t>((reg & 0x7E) | (half & 0x01));
+        };
+
+        auto decode32k = [&](uint8_t reg, uint8_t quarter, bool forceRom) {
+            w.ram = !forceRom && ((reg & 0x80) == 0);
+            w.writable = w.ram;
+            // In 32K mode, register bits 1..0 are ignored and CPU A14..A13 select 8K quarter.
+            w.bank8k = static_cast<uint8_t>((reg & 0x7C) | (quarter & 0x03));
+        };
+
+        switch(m_prgMode & 0x03) {
+        case 0:
+            decode32k(m_prgRegs[3], slot, true);
+            break;
+
+        case 1:
+            if(slot < 2) decode16k(m_prgRegs[1], slot & 0x01, false);
+            else decode16k(m_prgRegs[3], slot & 0x01, true);
+            break;
+
+        case 2:
+            if(slot < 2) decode16k(m_prgRegs[1], slot & 0x01, false);
+            else if(slot == 2) decode8k(m_prgRegs[2], false);
+            else decode8k(m_prgRegs[3], true);
+            break;
+
+        default:
+            if(slot == 0) decode8k(m_prgRegs[0], false);
+            else if(slot == 1) decode8k(m_prgRegs[1], false);
+            else if(slot == 2) decode8k(m_prgRegs[2], false);
+            else decode8k(m_prgRegs[3], true);
+            break;
+        }
+
+        return w;
+    }
+
+    GERANES_INLINE void updateChrMaps()
+    {
+        switch(m_chrMode & 0x03) {
+        case 0:
+            for(int i = 0; i < 8; ++i) {
+                m_chrMapA[i] = static_cast<uint16_t>((m_chrSpriteRegs[7] << 3) | i);
+                m_chrMapB[i] = static_cast<uint16_t>((m_chrBgRegs[3] << 3) | i);
+            }
+            break;
+        case 1:
+            for(int i = 0; i < 4; ++i) {
+                m_chrMapA[i] = static_cast<uint16_t>((m_chrSpriteRegs[3] << 2) | i);
+                m_chrMapA[i + 4] = static_cast<uint16_t>((m_chrSpriteRegs[7] << 2) | i);
+                m_chrMapB[i] = static_cast<uint16_t>((m_chrBgRegs[3] << 2) | i);
+                m_chrMapB[i + 4] = static_cast<uint16_t>((m_chrBgRegs[3] << 2) | i);
+            }
+            break;
+        case 2:
+            for(int i = 0; i < 2; ++i) {
+                m_chrMapA[i] = static_cast<uint16_t>((m_chrSpriteRegs[1] << 1) | i);
+                m_chrMapA[i + 2] = static_cast<uint16_t>((m_chrSpriteRegs[3] << 1) | i);
+                m_chrMapA[i + 4] = static_cast<uint16_t>((m_chrSpriteRegs[5] << 1) | i);
+                m_chrMapA[i + 6] = static_cast<uint16_t>((m_chrSpriteRegs[7] << 1) | i);
+                m_chrMapB[i] = static_cast<uint16_t>((m_chrBgRegs[1] << 1) | i);
+                m_chrMapB[i + 2] = static_cast<uint16_t>((m_chrBgRegs[3] << 1) | i);
+                m_chrMapB[i + 4] = static_cast<uint16_t>((m_chrBgRegs[1] << 1) | i);
+                m_chrMapB[i + 6] = static_cast<uint16_t>((m_chrBgRegs[3] << 1) | i);
+            }
+            break;
+        default:
+            for(int i = 0; i < 8; ++i) {
+                m_chrMapA[i] = m_chrSpriteRegs[i];
+                m_chrMapB[i] = m_chrBgRegs[i & 0x03];
+            }
+            break;
+        }
+    }
+
+    GERANES_INLINE uint16_t resolveChr1kBank(int addr) const
+    {
+        uint8_t page = static_cast<uint8_t>((addr >> 10) & 0x07);
+        uint16_t bank = 0;
+
+        // Split mode CHR mapping takes priority over extended attributes in the split region.
+        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80)) {
+            uint16_t bank4k = m_splitBank;
+            bank = static_cast<uint16_t>((bank4k << 2) | (page & 0x03));
+            return bank & m_chr1kMask;
+        }
+
+        // In extended attribute mode, background CHR uses ExRAM per-tile 4K bank selection.
+        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_exRamMode == 1) {
+            uint16_t bank4k = static_cast<uint16_t>(((m_chrUpperBits & 0x03) << 6) | (m_extAttrLatch & 0x3F));
+            bank = static_cast<uint16_t>((bank4k << 2) | (page & 0x03));
+            return bank & m_chr1kMask;
+        }
+
+        // MMC5: in 8x16 sprite mode while rendering, CHR-A is sprite-source and CHR-B is bg-source.
+        // Otherwise CHR source follows the last CHR register group written ($5120-$5127 or $5128-$512B).
+        bool useA = (m_abMode == 0);
+        if(m_sprite8x16 && m_renderingEnabled && m_substitutionsEnabled) {
+            useA = m_isSpriteFetch;
+        }
+
+        bank = useA ? m_chrMapA[page] : m_chrMapB[page];
+
+        return bank & m_chr1kMask;
+    }
+
+    GERANES_INLINE bool hasChrRom() const
+    {
+        return m_cd.chrSize() > 0;
+    }
+
+    GERANES_INLINE bool useChrRam() const
+    {
+        if(!hasChrRam()) {
+            return false;
+        }
+        if(!hasChrRom()) {
+            return true;
+        }
+        return m_chrRamEnable;
+    }
+
+    GERANES_INLINE void refreshChrMask()
+    {
+        m_chr1kMask = useChrRam() ? m_chrRam1kMask : m_chrRom1kMask;
+    }
+
+    GERANES_INLINE bool splitBackgroundActive() const
+    {
+        return !m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80);
+    }
+
+    GERANES_INLINE uint8_t splitFineY() const
+    {
+        return static_cast<uint8_t>(m_splitVScroll & 0x07);
+    }
+
+    GERANES_INLINE uint8_t splitCoarseY() const
+    {
+        return static_cast<uint8_t>((m_splitVScroll >> 3) & 0x1F);
+    }
+
+    GERANES_INLINE int applySplitPatternRow(int addr) const
+    {
+        if(splitBackgroundActive()) {
+            return (addr & ~0x07) | splitFineY();
+        }
+        return addr;
+    }
+
+public:
+    Mapper005(ICartridgeData& cd) : BaseMapper(cd)
+    {
+        m_prgRom8kMask = calculateMask(m_cd.numberOfPRGBanks<BankSize::B8K>());
+
+        if(hasChrRom()) {
+            m_chrRom1kMask = calculateMask16(m_cd.numberOfCHRBanks<BankSize::B1K>());
+        }
+        if(hasChrRam()) {
+            m_chrRam1kMask = calculateMask16(m_cd.chrRamSize() / static_cast<int>(BankSize::B1K));
+        }
+        refreshChrMask();
+
+        updateChrMaps();
+    }
+
+    void reset() override
+    {
+        // Keep mapper register/RAM contents, but clear runtime detector/split state.
+        // This is a practical approximation for reset behavior.
+        m_irqPending = false;
+        m_inFrame = false;
+        m_irqCounter = 0;
+        m_matchCount = 0;
+        m_ppuReading = false;
+        m_ppuReadAddress = 0;
+        m_lastPpuReadAddress = 0xFFFF;
+        m_idleCount = 0;
+        m_splitActive = false;
+        m_splitTileCount = 0;
+        m_splitScanline = 0;
+        m_splitVScroll = 0;
+        m_curTile = -1;
+        m_lineCounter = -2;
+        m_lastNtRead = 0xFFFF;
+        m_sameNtReadCount = 0;
+        m_lastSplitStateValid = false;
+        m_extAttrLatch = 0;
+        m_splitAttrLatch = 0;
+
+        // Multiplier power-on defaults per wiki notes.
+        m_mulA = 0xFF;
+        m_mulB = 0xFF;
+
+        m_mmc5aTimerCounter = 0;
+        m_mmc5aTimerActive = false;
+        m_mmc5aTimerIrqFlag = false;
+        refreshChrMask();
+    }
+
+    GERANES_HOT uint8_t readPrg(int addr) override
+    {
+        PrgWindow w = resolvePrgWindow(addr);
+
+        if(w.ram) {
+            return readPrgRam8k(w.bank8k, addr);
+        }
+
+        return readPrgRom8k(w.bank8k, addr);
+    }
+
+    GERANES_HOT void writePrg(int addr, uint8_t data) override
+    {
+        PrgWindow w = resolvePrgWindow(addr);
+
+        if(w.ram && w.writable) {
+            writePrgRam8k(w.bank8k, addr, data);
+        }
+    }
+
+    GERANES_HOT uint8_t readSaveRam(int addr) override
+    {
+        return readPrgRam8k(m_prgRamBank6000, addr);
+    }
+
+    GERANES_HOT void writeSaveRam(int addr, uint8_t data) override
+    {
+        writePrgRam8k(m_prgRamBank6000, addr, data);
+    }
+
+    GERANES_HOT void writeChr(int addr, uint8_t data) override
+    {
+        if(!useChrRam()) {
+            return;
+        }
+
+        int effectiveAddr = applySplitPatternRow(addr);
+        uint16_t bank = resolveChr1kBank(effectiveAddr);
+        writeChrRam<BankSize::B1K>(bank, effectiveAddr, data);
+    }
+
+    GERANES_HOT MirroringType mirroringType() override
+    {
+        return MirroringType::CUSTOM;
+    }
+
+    GERANES_HOT uint8_t customMirroring(uint8_t blockIndex) override
+    {
+        uint8_t mode = m_nameTableMap[blockIndex & 0x03] & 0x03;
+        if(mode <= 1) {
+            return mode;
+        }
+
+        // ExRAM/fill are handled via custom nametable hooks.
+        return 0;
+    }
+
+    GERANES_HOT bool useCustomNameTable(uint8_t index) override
+    {
+        return (m_nameTableMap[index & 0x03] & 0x03) >= 2;
+    }
+
+    GERANES_HOT uint8_t readCustomNameTable(uint8_t index, uint16_t addr) override
+    {
+        uint8_t mapMode = m_nameTableMap[index & 0x03] & 0x03;
+        addr &= 0x03FF;
+
+        if(mapMode == 2) {
+            if(m_exRamMode >= 2) {
+                return 0;
+            }
+            return m_exRam[addr];
+        }
+
+        if(mapMode == 3) {
+            if(addr < 0x03C0) {
+                return m_fillTile;
+            }
+            return fillAttributeByte();
+        }
+
+        return 0;
+    }
+
+    GERANES_HOT void writeCustomNameTable(uint8_t index, uint16_t addr, uint8_t data) override
+    {
+        uint8_t mapMode = m_nameTableMap[index & 0x03] & 0x03;
+        addr &= 0x03FF;
+
+        if(mapMode == 2) {
+            if((m_exRamMode == 0 || m_exRamMode == 1) && !m_renderingEnabled) {
+                m_exRam[addr] = data;
+            }
+        }
+    }
+
+    GERANES_HOT void writeMapperRegister(int addr, uint8_t data) override
+    {
+        uint16_t absolute = static_cast<uint16_t>(addr + 0x4000);
+
+        if(absolute >= 0x5C00 && absolute <= 0x5FFF) {
+            // MMC5Plus/Nintendulator behavior:
+            // mode 0/1: writes are only effective in-frame, otherwise write 0
+            // mode 2: read/write RAM
+            // mode 3: read-only (writes ignored)
+            if(m_exRamMode != 3) {
+                if(m_exRamMode == 2 || m_inFrame) {
+                    m_exRam[absolute & 0x03FF] = data;
+                }
+                else {
+                    m_exRam[absolute & 0x03FF] = 0;
+                }
+            }
+            return;
+        }
+
+        if(absolute >= 0x5800 && absolute <= 0x5BFF) {
+            m_mmc5aRam[absolute & 0x03FF] = data;
+            return;
+        }
+
+        switch(absolute) {
+        case 0x5000:
+        case 0x5001:
+        case 0x5002:
+        case 0x5003:
+            m_audioPulseRegs[0][absolute - 0x5000] = data;
+            break;
+
+        case 0x5004:
+        case 0x5005:
+        case 0x5006:
+        case 0x5007:
+            m_audioPulseRegs[1][absolute - 0x5004] = data;
+            break;
+
+        case 0x5010:
+            m_audioPcmControl = data;
+            break;
+
+        case 0x5011:
+            m_audioPcmValue = data;
+            break;
+
+        case 0x5015:
+            m_audioStatus &= static_cast<uint8_t>(~0x03);
+            m_audioStatus |= static_cast<uint8_t>(data & 0x03);
+            break;
+
+        case 0x5100:
+            m_prgMode = data & 0x03;
+            break;
+
+        case 0x5101:
+            m_chrModeByte = data;
+            m_chrMode = data & 0x03;
+            m_chrRamEnable = (data & 0x80) != 0;
+            refreshChrMask();
+            updateChrMaps();
+            traceLine(
+                "reg 5101 chrMode=" + std::to_string(m_chrMode) +
+                " chrRamEnable=" + std::to_string(m_chrRamEnable ? 1 : 0));
+            break;
+
+        case 0x5102:
+            m_prgRamProtect1 = data;
+            break;
+
+        case 0x5103:
+            m_prgRamProtect2 = data;
+            break;
+
+        case 0x5104:
+            m_exRamMode = data & 0x03;
+            traceLine("reg 5104 exRamMode=" + std::to_string(m_exRamMode));
+            break;
+
+        case 0x5105:
+            m_nameTableMap[0] = data & 0x03;
+            m_nameTableMap[1] = (data >> 2) & 0x03;
+            m_nameTableMap[2] = (data >> 4) & 0x03;
+            m_nameTableMap[3] = (data >> 6) & 0x03;
+            traceLine(
+                "reg 5105 ntMap=" + std::to_string(data) +
+                " [" + std::to_string(m_nameTableMap[0]) +
+                "," + std::to_string(m_nameTableMap[1]) +
+                "," + std::to_string(m_nameTableMap[2]) +
+                "," + std::to_string(m_nameTableMap[3]) + "]");
+            break;
+
+        case 0x5106:
+            m_fillTile = data;
+            break;
+
+        case 0x5107:
+            m_fillAttribute = data & 0x03;
+            break;
+
+        case 0x5113:
+            m_prgRamBank6000 = data & 0x07;
+            break;
+
+        case 0x5114:
+            m_prgRegs[0] = data;
+            break;
+
+        case 0x5115:
+            m_prgRegs[1] = data;
+            break;
+
+        case 0x5116:
+            m_prgRegs[2] = data;
+            break;
+
+        case 0x5117:
+            m_prgRegs[3] = data;
+            break;
+
+        case 0x5120:
+        case 0x5121:
+        case 0x5122:
+        case 0x5123:
+        case 0x5124:
+        case 0x5125:
+        case 0x5126:
+        case 0x5127:
+            m_abMode = 0;
+            m_chrSpriteRegs[absolute - 0x5120] = static_cast<uint16_t>(data | ((m_chrUpperBits & 0x03) << 8));
+            updateChrMaps();
+            traceLine("reg " + std::to_string(absolute) + " chra[" + std::to_string(absolute - 0x5120) + "]=" + std::to_string(data));
+            break;
+
+        case 0x5128:
+        case 0x5129:
+        case 0x512A:
+        case 0x512B:
+            m_abMode = 1;
+            m_chrBgRegs[absolute - 0x5128] = static_cast<uint16_t>(data | ((m_chrUpperBits & 0x03) << 8));
+            updateChrMaps();
+            traceLine("reg " + std::to_string(absolute) + " chrb[" + std::to_string(absolute - 0x5128) + "]=" + std::to_string(data));
+            break;
+
+        case 0x5130:
+            m_chrUpperBits = data & 0x03;
+            break;
+
+        case 0x5203:
+            m_irqScanline = data;
+            break;
+
+        case 0x5204:
+            m_irqEnable = (data & 0x80) != 0;
+            break;
+
+        case 0x5205:
+            m_mulA = data;
+            break;
+
+        case 0x5206:
+            m_mulB = data;
+            break;
+
+        case 0x5207:
+        case 0x5208:
+            m_mmc5aRegs[absolute - 0x5207] = data;
+            break;
+
+        case 0x5209:
+            m_mmc5aTimerCounter = static_cast<uint16_t>((m_mmc5aTimerCounter & 0xFF00) | data);
+            m_mmc5aTimerActive = (m_mmc5aTimerCounter != 0);
+            break;
+
+        case 0x520A:
+            m_mmc5aTimerCounter = static_cast<uint16_t>((m_mmc5aTimerCounter & 0x00FF) | (static_cast<uint16_t>(data) << 8));
+            break;
+
+        case 0x5200:
+            m_splitMode = data;
+            traceLine("reg 5200 splitMode=" + std::to_string(m_splitMode));
+            break;
+
+        case 0x5201:
+            m_splitScroll = data;
+            traceLine("reg 5201 splitScroll=" + std::to_string(m_splitScroll));
+            break;
+
+        case 0x5202:
+            m_splitBank = data;
+            traceLine("reg 5202 splitBank=" + std::to_string(m_splitBank));
+            break;
+        }
+    }
+
+    GERANES_HOT uint8_t readMapperRegister(int addr, uint8_t openBusData) override
+    {
+        uint16_t absolute = static_cast<uint16_t>(addr + 0x4000);
+
+        if(absolute >= 0x5C00 && absolute <= 0x5FFF) {
+            if(m_exRamMode <= 1) {
+                return openBusData;
+            }
+            return m_exRam[absolute & 0x03FF];
+        }
+
+        if(absolute >= 0x5800 && absolute <= 0x5BFF) {
+            return m_mmc5aRam[absolute & 0x03FF];
+        }
+
+        switch(absolute) {
+        case 0x5015:
+            return m_audioStatus;
+
+        case 0x5204: {
+            uint8_t ret = 0;
+            if(m_irqPending) ret |= 0x80;
+            if(m_inFrame) ret |= 0x40;
+            m_irqPending = false;
+            return ret;
+        }
+
+        case 0x5205:
+            return static_cast<uint8_t>((m_mulA * m_mulB) & 0x00FF);
+
+        case 0x5206:
+            return static_cast<uint8_t>(((m_mulA * m_mulB) >> 8) & 0x00FF);
+
+        case 0x5207:
+        case 0x5208:
+            return m_mmc5aRegs[absolute - 0x5207];
+
+        case 0x5209: {
+            if(m_mmc5aTimerActive) {
+                return 0;
+            }
+            uint8_t ret = static_cast<uint8_t>(m_mmc5aTimerIrqFlag ? 0x80 : 0x00);
+            m_mmc5aTimerIrqFlag = false;
+            return ret;
+        }
+
+        case 0x520A:
+            return openBusData;
+        }
+
+        return openBusData;
+    }
+
+    GERANES_HOT bool getInterruptFlag() override
+    {
+        return (m_irqEnable && m_irqPending) || m_mmc5aTimerIrqFlag;
+    }
+
+    GERANES_HOT void onScanlineStart(bool renderingEnabled, int scanline) override
+    {
+        m_renderingEnabled = renderingEnabled;
+
+        if(!renderingEnabled) {
+            m_inFrame = false;
+            m_splitActive = false;
+            m_splitTileCount = 0;
+            m_splitScanline = 0;
+            m_splitAttrLatch = 0;
+            return;
+        }
+
+        m_splitActive = false;
+        m_splitTileCount = 0;
+        m_splitAttrLatch = 0;
+        if(scanline >= 0 && scanline < 240) {
+            m_splitScanline = static_cast<uint8_t>(scanline);
+        }
+        else {
+            m_splitScanline = 0;
+        }
+    }
+
+    void serialization(SerializationBase& s) override
+    {
+        BaseMapper::serialization(s);
+
+        SERIALIZEDATA(s, m_prgMode);
+        SERIALIZEDATA(s, m_chrMode);
+        SERIALIZEDATA(s, m_chrModeByte);
+        SERIALIZEDATA(s, m_chrRamEnable);
+        SERIALIZEDATA(s, m_exRamMode);
+
+        SERIALIZEDATA(s, m_prgRamProtect1);
+        SERIALIZEDATA(s, m_prgRamProtect2);
+
+        s.array(m_nameTableMap, 1, 4);
+
+        SERIALIZEDATA(s, m_fillTile);
+        SERIALIZEDATA(s, m_fillAttribute);
+
+        SERIALIZEDATA(s, m_prgRamBank6000);
+
+        s.array(m_prgRegs, 1, 4);
+        s.array(reinterpret_cast<uint8_t*>(m_chrSpriteRegs), 1, static_cast<int>(sizeof(m_chrSpriteRegs)));
+        s.array(reinterpret_cast<uint8_t*>(m_chrBgRegs), 1, static_cast<int>(sizeof(m_chrBgRegs)));
+        s.array(reinterpret_cast<uint8_t*>(m_chrMapA), 1, static_cast<int>(sizeof(m_chrMapA)));
+        s.array(reinterpret_cast<uint8_t*>(m_chrMapB), 1, static_cast<int>(sizeof(m_chrMapB)));
+        SERIALIZEDATA(s, m_chrUpperBits);
+        SERIALIZEDATA(s, m_abMode);
+
+        SERIALIZEDATA(s, m_irqScanline);
+        SERIALIZEDATA(s, m_irqEnable);
+        SERIALIZEDATA(s, m_irqPending);
+        SERIALIZEDATA(s, m_inFrame);
+        SERIALIZEDATA(s, m_irqCounter);
+        SERIALIZEDATA(s, m_matchCount);
+        SERIALIZEDATA(s, m_ppuReading);
+        SERIALIZEDATA(s, m_ppuReadAddress);
+        SERIALIZEDATA(s, m_lastPpuReadAddress);
+        SERIALIZEDATA(s, m_idleCount);
+
+        SERIALIZEDATA(s, m_mulA);
+        SERIALIZEDATA(s, m_mulB);
+        s.array(reinterpret_cast<uint8_t*>(m_audioPulseRegs), 1, static_cast<int>(sizeof(m_audioPulseRegs)));
+        SERIALIZEDATA(s, m_audioPcmControl);
+        SERIALIZEDATA(s, m_audioPcmValue);
+        SERIALIZEDATA(s, m_audioStatus);
+        s.array(reinterpret_cast<uint8_t*>(m_mmc5aRegs), 1, static_cast<int>(sizeof(m_mmc5aRegs)));
+        SERIALIZEDATA(s, m_mmc5aTimerCounter);
+        SERIALIZEDATA(s, m_mmc5aTimerActive);
+        SERIALIZEDATA(s, m_mmc5aTimerIrqFlag);
+
+        SERIALIZEDATA(s, m_prgRom8kMask);
+        SERIALIZEDATA(s, m_chrRom1kMask);
+        SERIALIZEDATA(s, m_chrRam1kMask);
+        SERIALIZEDATA(s, m_chr1kMask);
+        SERIALIZEDATA(s, m_isSpriteFetch);
+        SERIALIZEDATA(s, m_sprite8x16);
+        SERIALIZEDATA(s, m_renderingEnabled);
+        SERIALIZEDATA(s, m_extAttrLatch);
+        SERIALIZEDATA(s, m_splitAttrLatch);
+        SERIALIZEDATA(s, m_splitMode);
+        SERIALIZEDATA(s, m_splitScroll);
+        SERIALIZEDATA(s, m_splitBank);
+        SERIALIZEDATA(s, m_splitVScroll);
+        SERIALIZEDATA(s, m_splitActive);
+        SERIALIZEDATA(s, m_splitTileCount);
+        SERIALIZEDATA(s, m_splitScanline);
+        SERIALIZEDATA(s, m_curTile);
+        SERIALIZEDATA(s, m_lineCounter);
+        SERIALIZEDATA(s, m_lastNtRead);
+        SERIALIZEDATA(s, m_sameNtReadCount);
+
+        s.array(m_exRam.data(), 1, static_cast<int>(m_exRam.size()));
+        s.array(m_mmc5aRam.data(), 1, static_cast<int>(m_mmc5aRam.size()));
+        s.array(m_prgRam.data(), 1, static_cast<int>(m_prgRam.size()));
+        refreshChrMask();
+    }
+
+    GERANES_HOT void setPpuFetchSource(bool isSpriteFetch) override
+    {
+        m_isSpriteFetch = isSpriteFetch;
+    }
+
+    GERANES_HOT void setSpriteSize8x16(bool sprite8x16) override
+    {
+        m_sprite8x16 = sprite8x16;
+        traceLine(std::string("ppu sprite8x16=") + (m_sprite8x16 ? "1" : "0"));
+    }
+
+    GERANES_HOT void setPpuReadAffectsBus(bool affectsBus) override
+    {
+        (void)affectsBus;
+    }
+
+    GERANES_HOT void setPpuMask(uint8_t mask) override
+    {
+        bool newEnabled = (mask & 0x18) != 0;
+        traceLine(
+            "ppu mask=" + std::to_string(mask) +
+            " bg=" + std::to_string((mask & 0x08) ? 1 : 0) +
+            " spr=" + std::to_string((mask & 0x10) ? 1 : 0) +
+            " subs=" + std::to_string(newEnabled ? 1 : 0));
+        m_substitutionsEnabled = newEnabled;
+
+        // MMC5+ behavior (mirrors Nintendulator): when both BG and sprites are disabled,
+        // reset frame/read detector state.
+        if(!newEnabled) {
+            m_inFrame = false;
+            m_lineCounter = -2;
+            m_splitActive = false;
+            m_splitTileCount = 0;
+            m_splitAttrLatch = 0;
+            m_curTile = -1;
+        }
+    }
+
+    GERANES_HOT void onPpuStatusRead(bool vblankSet) override
+    {
+        (void)vblankSet;
+    }
+
+    GERANES_HOT void onCpuRead(uint16_t addr) override
+    {
+        (void)addr;
+    }
+
+    GERANES_HOT void onPpuRead(uint16_t addr) override
+    {
+        m_ppuReadAddress = static_cast<uint16_t>(addr & 0x3FFF);
+    }
+
+    GERANES_HOT void cycle() override
+    {
+        if(m_mmc5aTimerActive && m_mmc5aTimerCounter > 0) {
+            if(m_mmc5aTimerCounter == 1) {
+                m_mmc5aTimerCounter = 0;
+                m_mmc5aTimerActive = false;
+                m_mmc5aTimerIrqFlag = true;
+            }
+            else {
+                --m_mmc5aTimerCounter;
+            }
+        }
+    }
+
+    GERANES_HOT void onPpuCycle(int scanline, int cycle, bool isRendering, bool isPreLine) override
+    {
+        if(scanline == 240 && cycle == 0) {
+            m_splitActive = false;
+            m_splitTileCount = 0;
+            m_splitAttrLatch = 0;
+            m_curTile = -1;
+            m_lineCounter = -2;
+            m_inFrame = false;
+        }
+
+        if(!isRendering) {
+            return;
+        }
+
+        if(cycle == 0) {
+            if(scanline == 0) {
+                m_irqPending = false;
+            }
+            if(scanline == 1) {
+                m_inFrame = true;
+            }
+
+            if(m_lineCounter < 0x7FFF) {
+                ++m_lineCounter;
+            }
+            if(m_irqScanline != 0 && m_lineCounter == static_cast<int16_t>(m_irqScanline)) {
+                m_irqPending = true;
+            }
+        }
+
+        if(cycle == 320) {
+            m_curTile = -1;
+            m_splitTileCount = 0;
+
+            if(isPreLine) {
+                m_splitVScroll = m_splitScroll;
+                if(m_splitVScroll >= 240) {
+                    m_splitVScroll = static_cast<uint8_t>(m_splitVScroll - 16);
+                }
+            }
+            else if(scanline >= 0 && scanline < 240) {
+                m_splitVScroll = static_cast<uint8_t>(m_splitVScroll + 1);
+            }
+
+            if(m_splitVScroll >= 240) {
+                m_splitVScroll = static_cast<uint8_t>(m_splitVScroll - 240);
+            }
+        }
+
+        if((cycle & 0x07) == 0 && cycle < 336) {
+            ++m_curTile;
+
+            bool splitEnabled = (m_splitMode & 0x80) && ((m_exRamMode & 0x02) == 0);
+            if(!splitEnabled) {
+                m_splitActive = false;
+                return;
+            }
+
+            uint8_t threshold = m_splitMode & 0x1F;
+            bool splitRight = (m_splitMode & 0x40) != 0;
+            if(splitRight) {
+                if(m_curTile == 0) {
+                    m_splitActive = false;
+                }
+                else if(m_curTile == threshold) {
+                    m_splitActive = true;
+                }
+                else if(m_curTile == 34) {
+                    m_splitActive = false;
+                }
+            }
+            else {
+                if(m_curTile == 0) {
+                    m_splitActive = true;
+                }
+                else if(m_curTile == threshold) {
+                    m_splitActive = false;
+                }
+                else if(m_curTile >= 34) {
+                    m_splitActive = false;
+                }
+            }
+        }
+    }
+
+    GERANES_HOT uint8_t transformNameTableRead(uint8_t index, uint16_t addr, uint8_t value) override
+    {
+        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && addr < 0x03C0) {
+            ++m_splitTileCount;
+            int curTile = m_curTile;
+            if(curTile < 0) {
+                curTile = static_cast<int>(m_splitTileCount) - 1;
+            }
+            uint8_t fetchTileX = static_cast<uint8_t>(curTile & 0x1F);
+
+            bool splitEnabled = (m_splitMode & 0x80) && ((m_exRamMode & 0x02) == 0);
+            if(!splitEnabled) {
+                m_splitActive = false;
+            }
+
+            if(m_splitActive && splitEnabled) {
+                uint8_t tileY = splitCoarseY();
+                uint8_t splitTileX = fetchTileX;
+                uint16_t exAddr = static_cast<uint16_t>(((tileY << 5) | splitTileX) & 0x03FF);
+                uint16_t attrAddr = static_cast<uint16_t>((0x03C0 | ((tileY >> 2) << 3) | (splitTileX >> 2)) & 0x03FF);
+                m_extAttrLatch = m_exRam[exAddr];
+                uint8_t attrByte = m_exRam[attrAddr];
+                uint8_t shift = static_cast<uint8_t>(((tileY & 0x02) << 1) | (splitTileX & 0x02));
+                m_splitAttrLatch = expandPaletteBits(static_cast<uint8_t>((attrByte >> shift) & 0x03));
+                value = m_extAttrLatch;
+                if(fetchTileX == 0 || fetchTileX == 16 || fetchTileX == 31) {
+                    traceLine(
+                        "split nt idx=" + std::to_string(index) +
+                        " x=" + std::to_string(fetchTileX) +
+                        " y=" + std::to_string(m_splitScanline) +
+                        " ex=" + std::to_string(exAddr) +
+                        " exv=" + std::to_string(m_extAttrLatch));
+                }
+            }
+            else {
+                m_extAttrLatch = m_exRam[addr & 0x03FF];
+                m_splitAttrLatch = 0;
+            }
+
+            if(splitEnabled && (!m_lastSplitStateValid || m_lastSplitActiveLogged != m_splitActive)) {
+                m_lastSplitStateValid = true;
+                m_lastSplitActiveLogged = m_splitActive;
+                traceLine(
+                    "split state active=" + std::to_string(m_splitActive ? 1 : 0) +
+                    " mode=" + std::to_string(m_splitMode) +
+                    " x=" + std::to_string(fetchTileX) +
+                    " nt=" + std::to_string(index));
+            }
+        }
+        else {
+            if(m_splitMode & 0x80) {
+                m_lastSplitStateValid = false;
+            }
+        }
+
+        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && addr >= 0x03C0 && m_splitActive && (m_splitMode & 0x80)) {
+            return m_splitAttrLatch;
+        }
+
+        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_exRamMode == 1 && addr >= 0x03C0) {
+            uint8_t p = (m_extAttrLatch >> 6) & 0x03;
+            return expandPaletteBits(p);
+        }
+
+        return value;
+    }
+
+    GERANES_HOT uint8_t readChr(int addr) override
+    {
+        int effectiveAddr = applySplitPatternRow(addr);
+        uint16_t bank = resolveChr1kBank(effectiveAddr);
+        uint8_t page = static_cast<uint8_t>((effectiveAddr >> 10) & 0x07);
+
+        if(m_traceChr && (page != m_lastLoggedChrPage || bank != m_lastLoggedChrBank)) {
+            m_lastLoggedChrPage = page;
+            m_lastLoggedChrBank = bank;
+            traceLine(
+                "chr page=" + std::to_string(page) +
+                " bank=" + std::to_string(bank) +
+                " mode=" + std::to_string(m_chrMode) +
+                " spr=" + std::to_string(m_isSpriteFetch ? 1 : 0) +
+                " spr8x16=" + std::to_string(m_sprite8x16 ? 1 : 0) +
+                " exMode=" + std::to_string(m_exRamMode) +
+                " split=" + std::to_string(m_splitActive ? 1 : 0));
+        }
+
+        if(useChrRam()) {
+            return readChrRam<BankSize::B1K>(bank, effectiveAddr);
+        }
+
+        return m_cd.readChr<BankSize::B1K>(bank, effectiveAddr);
+    }
+};

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -1181,7 +1181,7 @@ public:
             }
 
             // ExRAM mode 1 pipeline: NT fetch arms AT+CHR substitution for this tile.
-            if(!m_isSpriteFetch && m_exRamMode == 1 && (tileNumber < 32 || tileNumber >= 40) && !m_splitActive) {
+            if(!m_isSpriteFetch && m_exRamMode == 1 && (tileNumber <= 32 || tileNumber >= 40) && !m_splitActive) {
                 m_extAttrLatch = m_exRam[addr & 0x03FF];
                 m_exAttrSelectedChrBank = static_cast<uint16_t>(((m_chrUpperBits & 0x03) << 6) | (m_extAttrLatch & 0x3F));
                 m_exAttrFetchCounter = 3;

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -95,6 +95,8 @@ private:
     bool m_renderingEnabled = false;
     bool m_substitutionsEnabled = false;
     uint8_t m_extAttrLatch = 0;
+    uint8_t m_exAttrFetchCounter = 0;
+    uint16_t m_exAttrSelectedChrBank = 0;
     uint8_t m_splitAttrLatch = 0;
     uint8_t m_splitMode = 0;
     uint8_t m_splitScroll = 0;
@@ -399,15 +401,8 @@ private:
         uint16_t bank = 0;
 
         // Split mode CHR mapping takes priority over extended attributes in the split region.
-        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80)) {
+        if(!m_isSpriteFetch && m_inFrame && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80)) {
             uint16_t bank4k = m_splitBank;
-            bank = static_cast<uint16_t>((bank4k << 2) | (page & 0x03));
-            return bank & m_chr1kMask;
-        }
-
-        // In extended attribute mode, background CHR uses ExRAM per-tile 4K bank selection.
-        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_exRamMode == 1) {
-            uint16_t bank4k = static_cast<uint16_t>(((m_chrUpperBits & 0x03) << 6) | (m_extAttrLatch & 0x3F));
             bank = static_cast<uint16_t>((bank4k << 2) | (page & 0x03));
             return bank & m_chr1kMask;
         }
@@ -447,7 +442,7 @@ private:
 
     GERANES_INLINE bool splitBackgroundActive() const
     {
-        return !m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80);
+        return !m_isSpriteFetch && m_inFrame && m_renderingEnabled && m_substitutionsEnabled && m_splitActive && (m_splitMode & 0x80);
     }
 
     GERANES_INLINE uint8_t splitFineY() const
@@ -505,6 +500,8 @@ public:
         m_lastNtRead = 0xFFFF;
         m_sameNtReadCount = 0;
         m_extAttrLatch = 0;
+        m_exAttrFetchCounter = 0;
+        m_exAttrSelectedChrBank = 0;
         m_splitAttrLatch = 0;
 
         // Multiplier power-on defaults per wiki notes.
@@ -879,16 +876,17 @@ public:
         m_renderingEnabled = renderingEnabled;
 
         if(!renderingEnabled) {
-            m_inFrame = false;
             m_splitActive = false;
             m_splitTileCount = 0;
             m_splitScanline = 0;
+            m_exAttrFetchCounter = 0;
             m_splitAttrLatch = 0;
             return;
         }
 
         m_splitActive = false;
         m_splitTileCount = 0;
+        m_exAttrFetchCounter = 0;
         m_splitAttrLatch = 0;
         if(scanline >= 0 && scanline < 240) {
             m_splitScanline = static_cast<uint8_t>(scanline);
@@ -968,6 +966,8 @@ public:
         SERIALIZEDATA(s, m_sprite8x16);
         SERIALIZEDATA(s, m_renderingEnabled);
         SERIALIZEDATA(s, m_extAttrLatch);
+        SERIALIZEDATA(s, m_exAttrFetchCounter);
+        SERIALIZEDATA(s, m_exAttrSelectedChrBank);
         SERIALIZEDATA(s, m_splitAttrLatch);
         SERIALIZEDATA(s, m_splitMode);
         SERIALIZEDATA(s, m_splitScroll);
@@ -1005,7 +1005,6 @@ public:
         // MMC5+ behavior (mirrors Nintendulator): when both BG and sprites are disabled,
         // reset frame/read detector state.
         if(!newEnabled) {
-            m_inFrame = false;
             m_lineCounter = -2;
             m_splitActive = false;
             m_splitTileCount = 0;
@@ -1027,6 +1026,7 @@ public:
     GERANES_HOT void onPpuRead(uint16_t addr) override
     {
         m_ppuReadAddress = static_cast<uint16_t>(addr & 0x3FFF);
+        m_ppuReading = true;
     }
 
     GERANES_HOT void cycle() override
@@ -1057,18 +1057,35 @@ public:
             clockPulseLength(1);
         }
 
+        if(m_ppuReading) {
+            m_ppuReading = false;
+            m_idleCount = 0;
+            m_lastPpuReadAddress = m_ppuReadAddress;
+        }
+        else {
+            if(m_idleCount < 0xFF) {
+                ++m_idleCount;
+            }
+
+            // MMC5 keeps "in-frame" asserted briefly after the last PPU read.
+            if(m_idleCount >= 3) {
+                m_inFrame = false;
+            }
+        }
+
         updateExpansionAudioSample();
     }
 
     GERANES_HOT void onPpuCycle(int scanline, int cycle, bool isRendering, bool isPreLine) override
     {
+        (void)isPreLine;
         if(scanline == 240 && cycle == 0) {
             m_splitActive = false;
             m_splitTileCount = 0;
+            m_exAttrFetchCounter = 0;
             m_splitAttrLatch = 0;
             m_curTile = -1;
             m_lineCounter = -2;
-            m_inFrame = false;
         }
 
         if(!isRendering) {
@@ -1081,6 +1098,7 @@ public:
             }
             if(scanline == 1) {
                 m_inFrame = true;
+                m_idleCount = 0;
             }
 
             if(m_lineCounter < 0x7FFF) {
@@ -1093,99 +1111,98 @@ public:
 
         if(cycle == 320) {
             m_curTile = -1;
-            m_splitTileCount = 0;
-
-            if(isPreLine) {
-                m_splitVScroll = m_splitScroll;
-                if(m_splitVScroll >= 240) {
-                    m_splitVScroll = static_cast<uint8_t>(m_splitVScroll - 16);
-                }
-            }
-            else if(scanline >= 0 && scanline < 240) {
-                m_splitVScroll = static_cast<uint8_t>(m_splitVScroll + 1);
-            }
-
-            if(m_splitVScroll >= 240) {
-                m_splitVScroll = static_cast<uint8_t>(m_splitVScroll - 240);
-            }
         }
 
         if((cycle & 0x07) == 0 && cycle < 336) {
             ++m_curTile;
-
-            bool splitEnabled = (m_splitMode & 0x80) && ((m_exRamMode & 0x02) == 0);
-            if(!splitEnabled) {
-                m_splitActive = false;
-                return;
-            }
-
-            uint8_t threshold = m_splitMode & 0x1F;
-            bool splitRight = (m_splitMode & 0x40) != 0;
-            if(splitRight) {
-                if(m_curTile == 0) {
-                    m_splitActive = false;
-                }
-                else if(m_curTile == threshold) {
-                    m_splitActive = true;
-                }
-                else if(m_curTile == 34) {
-                    m_splitActive = false;
-                }
-            }
-            else {
-                if(m_curTile == 0) {
-                    m_splitActive = true;
-                }
-                else if(m_curTile == threshold) {
-                    m_splitActive = false;
-                }
-                else if(m_curTile >= 34) {
-                    m_splitActive = false;
-                }
-            }
         }
     }
 
     GERANES_HOT uint8_t transformNameTableRead(uint8_t index, uint16_t addr, uint8_t value) override
     {
-        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && addr < 0x03C0) {
-            ++m_splitTileCount;
-            int curTile = m_curTile;
-            if(curTile < 0) {
-                curTile = static_cast<int>(m_splitTileCount) - 1;
-            }
-            uint8_t fetchTileX = static_cast<uint8_t>(curTile & 0x1F);
+        (void)index;
+        if(!(m_renderingEnabled && m_substitutionsEnabled)) {
+            return value;
+        }
 
-            bool splitEnabled = (m_splitMode & 0x80) && ((m_exRamMode & 0x02) == 0);
-            if(!splitEnabled) {
+        // MMC5 split/ex-attr substitutions are valid only while in-frame.
+        if(!m_inFrame) {
+            return value;
+        }
+
+        const bool isNtFetch = addr < 0x03C0;
+        const bool splitEnabled = (m_splitMode & 0x80) && ((m_exRamMode & 0x02) == 0);
+
+        int tileNumber = static_cast<int>(m_splitTileCount);
+        uint8_t splitTileX = 0;
+        if(isNtFetch) {
+            ++m_splitTileCount;
+            tileNumber = static_cast<int>(m_splitTileCount);
+
+            if(splitEnabled) {
+                // MMC5 split region follows nametable fetch order with a +2 pipeline offset.
+                uint8_t column = static_cast<uint8_t>((tileNumber + 2) % 42);
+                bool splitRight = (m_splitMode & 0x40) != 0;
+                uint8_t threshold = m_splitMode & 0x1F;
+
+                if(column == 0) {
+                    m_splitActive = !splitRight;
+                }
+
+                if(column == threshold && tileNumber < 42) {
+                    m_splitActive = !m_splitActive;
+                }
+                else if(column > 32) {
+                    m_splitActive = false;
+                }
+
+                splitTileX = static_cast<uint8_t>(column & 0x1F);
+
+                uint8_t splitY = m_splitScanline;
+                if(tileNumber >= 41) {
+                    splitY = static_cast<uint8_t>((splitY + 1) % 240);
+                }
+                m_splitVScroll = static_cast<uint8_t>((splitY + m_splitScroll) % 240);
+            }
+            else {
                 m_splitActive = false;
             }
 
-            if(m_splitActive && splitEnabled) {
+            if(!m_isSpriteFetch && m_splitActive && splitEnabled) {
                 uint8_t tileY = splitCoarseY();
-                uint8_t splitTileX = fetchTileX;
                 uint16_t exAddr = static_cast<uint16_t>(((tileY << 5) | splitTileX) & 0x03FF);
                 uint16_t attrAddr = static_cast<uint16_t>((0x03C0 | ((tileY >> 2) << 3) | (splitTileX >> 2)) & 0x03FF);
                 m_extAttrLatch = m_exRam[exAddr];
                 uint8_t attrByte = m_exRam[attrAddr];
                 uint8_t shift = static_cast<uint8_t>(((tileY & 0x02) << 1) | (splitTileX & 0x02));
                 m_splitAttrLatch = expandPaletteBits(static_cast<uint8_t>((attrByte >> shift) & 0x03));
-                value = m_extAttrLatch;
-            }
-            else {
-                m_extAttrLatch = m_exRam[addr & 0x03FF];
-                m_splitAttrLatch = 0;
+                m_exAttrFetchCounter = 0;
+                return m_extAttrLatch;
             }
 
+            // ExRAM mode 1 pipeline: NT fetch arms AT+CHR substitution for this tile.
+            if(!m_isSpriteFetch && m_exRamMode == 1 && (tileNumber < 32 || tileNumber >= 40) && !m_splitActive) {
+                m_extAttrLatch = m_exRam[addr & 0x03FF];
+                m_exAttrSelectedChrBank = static_cast<uint16_t>(((m_chrUpperBits & 0x03) << 6) | (m_extAttrLatch & 0x3F));
+                m_exAttrFetchCounter = 3;
+            }
+            else if(!m_isSpriteFetch) {
+                m_exAttrFetchCounter = 0;
+            }
+
+            return value;
         }
 
-        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && addr >= 0x03C0 && m_splitActive && (m_splitMode & 0x80)) {
+        if(!m_isSpriteFetch && m_splitActive && splitEnabled) {
             return m_splitAttrLatch;
         }
 
-        if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && m_exRamMode == 1 && addr >= 0x03C0) {
-            uint8_t p = (m_extAttrLatch >> 6) & 0x03;
-            return expandPaletteBits(p);
+        if(!m_isSpriteFetch && m_exRamMode == 1 && m_exAttrFetchCounter > 0) {
+            --m_exAttrFetchCounter;
+            if(m_exAttrFetchCounter == 2) {
+                uint8_t p = static_cast<uint8_t>((m_extAttrLatch >> 6) & 0x03);
+                return expandPaletteBits(p);
+            }
         }
 
         return value;
@@ -1194,6 +1211,21 @@ public:
     GERANES_HOT uint8_t readChr(int addr) override
     {
         int effectiveAddr = applySplitPatternRow(addr);
+
+        // ExRAM mode 1 substitutes only the 2 CHR fetches that follow the attribute fetch.
+        if(!m_isSpriteFetch && m_inFrame && m_renderingEnabled && m_substitutionsEnabled && m_exRamMode == 1 &&
+           !splitBackgroundActive() && m_exAttrFetchCounter > 0) {
+            --m_exAttrFetchCounter;
+            uint16_t bank = static_cast<uint16_t>((m_exAttrSelectedChrBank << 2) | ((effectiveAddr >> 10) & 0x03));
+            bank &= m_chr1kMask;
+
+            if(useChrRam()) {
+                return readChrRam<BankSize::B1K>(bank, effectiveAddr);
+            }
+
+            return m_cd.readChr<BankSize::B1K>(bank, effectiveAddr);
+        }
+
         uint16_t bank = resolveChr1kBank(effectiveAddr);
 
         if(useChrRam()) {

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -2,10 +2,12 @@
 
 #include <array>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <sstream>
 
 #include "BaseMapper.h"
+#include "../APU/APUCommon.h"
 
 // MMC5
 // Implemented features in this mapper:
@@ -14,12 +16,10 @@
 // - Extended nametable mapping (CIRAM/ExRAM/fill) ($5104-$5107)
 // - Scanline IRQ core registers ($5203/$5204)
 // - 8x8 multiplier ($5205/$5206)
-//
-// Not implemented in this mapper:
-// - Expansion audio
+// - Expansion audio (2 pulse channels + PCM DAC) ($5000-$5015)
 class Mapper005 : public BaseMapper
 {
-private:
+private: // GERA VIADÃO!!!!!!!
     uint8_t m_prgMode = 3;
     uint8_t m_chrMode = 3;
     uint8_t m_chrModeByte = 3;
@@ -63,6 +63,27 @@ private:
     uint8_t m_audioPcmControl = 0;
     uint8_t m_audioPcmValue = 0;
     uint8_t m_audioStatus = 0;
+    bool m_audioPcmLatched = false;
+
+    struct ExpansionPulseState {
+        uint16_t timerCounter = 0;
+        uint8_t dutyStep = 0;
+        uint8_t lengthCounter = 0;
+        uint8_t envelopeDivider = 0;
+        uint8_t envelopeVolume = 0;
+        bool envelopeStart = false;
+    };
+    ExpansionPulseState m_expPulse[2] = {};
+    int m_expQuarterCounter = 0;
+    int m_expHalfCounter = 0;
+    float m_expansionAudioSample = 0.0f;
+
+    static constexpr uint8_t MMC5_DUTY_TABLE[4][8] = {
+        {0, 1, 0, 0, 0, 0, 0, 0},
+        {0, 1, 1, 0, 0, 0, 0, 0},
+        {0, 1, 1, 1, 1, 0, 0, 0},
+        {1, 0, 0, 1, 1, 1, 1, 1}
+    };
     uint8_t m_mmc5aRegs[2] = {0}; // $5207/$5208
     uint16_t m_mmc5aTimerCounter = 0; // $5209/$520A
     bool m_mmc5aTimerActive = false;
@@ -103,6 +124,141 @@ private:
     std::array<uint8_t, 0x400> m_exRam = {};
     std::array<uint8_t, 0x400> m_mmc5aRam = {};
     std::array<uint8_t, 0x10000> m_prgRam = {};
+
+    GERANES_INLINE uint16_t pulsePeriod(int channel) const
+    {
+        return static_cast<uint16_t>(
+            (static_cast<uint16_t>(m_audioPulseRegs[channel][3] & 0x07) << 8) |
+            m_audioPulseRegs[channel][2]);
+    }
+
+    GERANES_INLINE uint8_t pulseDuty(int channel) const
+    {
+        return static_cast<uint8_t>((m_audioPulseRegs[channel][0] >> 6) & 0x03);
+    }
+
+    GERANES_INLINE bool pulseLengthHalt(int channel) const
+    {
+        return (m_audioPulseRegs[channel][0] & 0x20) != 0;
+    }
+
+    GERANES_INLINE bool pulseConstantVolumeMode(int channel) const
+    {
+        return (m_audioPulseRegs[channel][0] & 0x10) != 0;
+    }
+
+    GERANES_INLINE uint8_t pulseVolumeParam(int channel) const
+    {
+        return static_cast<uint8_t>(m_audioPulseRegs[channel][0] & 0x0F);
+    }
+
+    GERANES_INLINE void clockPulseEnvelope(int channel)
+    {
+        ExpansionPulseState& p = m_expPulse[channel];
+
+        if(p.envelopeStart) {
+            p.envelopeStart = false;
+            p.envelopeVolume = 0x0F;
+            p.envelopeDivider = static_cast<uint8_t>(pulseVolumeParam(channel) + 1);
+            return;
+        }
+
+        if(p.envelopeDivider > 0) {
+            --p.envelopeDivider;
+        }
+
+        if(p.envelopeDivider == 0) {
+            p.envelopeDivider = static_cast<uint8_t>(pulseVolumeParam(channel) + 1);
+            if(p.envelopeVolume > 0) {
+                --p.envelopeVolume;
+            }
+            else if(pulseLengthHalt(channel)) {
+                p.envelopeVolume = 0x0F;
+            }
+        }
+    }
+
+    GERANES_INLINE void clockPulseLength(int channel)
+    {
+        if((m_audioStatus & (1 << channel)) == 0) {
+            return;
+        }
+
+        ExpansionPulseState& p = m_expPulse[channel];
+        if(!pulseLengthHalt(channel) && p.lengthCounter > 0) {
+            --p.lengthCounter;
+        }
+    }
+
+    GERANES_INLINE void stepPulseTimer(int channel)
+    {
+        ExpansionPulseState& p = m_expPulse[channel];
+        const uint16_t period = pulsePeriod(channel);
+        uint16_t timerPeriod = static_cast<uint16_t>((period + 1) << 1);
+        if(timerPeriod < 2) {
+            timerPeriod = 2;
+        }
+
+        if(p.timerCounter == 0) {
+            p.timerCounter = static_cast<uint16_t>(timerPeriod - 1);
+            p.dutyStep = static_cast<uint8_t>((p.dutyStep + 1) & 0x07);
+        }
+        else {
+            --p.timerCounter;
+        }
+    }
+
+    GERANES_INLINE float pulseOutput(int channel) const
+    {
+        if((m_audioStatus & (1 << channel)) == 0) {
+            return 0.0f;
+        }
+
+        const ExpansionPulseState& p = m_expPulse[channel];
+        if(p.lengthCounter == 0) {
+            return 0.0f;
+        }
+
+        if(pulsePeriod(channel) < 8) {
+            return 0.0f;
+        }
+
+        const uint8_t duty = pulseDuty(channel);
+        const uint8_t dutyBit = MMC5_DUTY_TABLE[duty][p.dutyStep];
+        const uint8_t rawVolume = pulseConstantVolumeMode(channel) ? pulseVolumeParam(channel) : p.envelopeVolume;
+        const float volume = static_cast<float>(rawVolume) / 15.0f;
+
+        return dutyBit ? volume : -volume;
+    }
+
+    GERANES_INLINE void updateExpansionAudioSample()
+    {
+        const float pulseMix = (pulseOutput(0) + pulseOutput(1)) * 0.5f;
+        const float pcm = m_audioPcmLatched ? (static_cast<float>(static_cast<int>(m_audioPcmValue) - 128) / 128.0f) : 0.0f;
+
+        float out = pulseMix * 0.60f + pcm * 0.25f;
+        if(out > 1.0f) out = 1.0f;
+        else if(out < -1.0f) out = -1.0f;
+
+        m_expansionAudioSample = out;
+    }
+
+    GERANES_INLINE void writePulseRegister(int channel, int reg, uint8_t data)
+    {
+        m_audioPulseRegs[channel][reg] = data;
+        ExpansionPulseState& p = m_expPulse[channel];
+
+        if(reg == 3) {
+            if(m_audioStatus & (1 << channel)) {
+                p.lengthCounter = LENGTH_TABLE[(data >> 3) & 0x1F];
+            }
+            p.envelopeStart = true;
+            p.dutyStep = 0;
+            uint16_t timerPeriod = static_cast<uint16_t>((pulsePeriod(channel) + 1) << 1);
+            if(timerPeriod < 2) timerPeriod = 2;
+            p.timerCounter = static_cast<uint16_t>(timerPeriod - 1);
+        }
+    }
 
     GERANES_INLINE uint16_t calculateMask16(int nBanks) const
     {
@@ -413,6 +569,15 @@ public:
         m_mmc5aTimerCounter = 0;
         m_mmc5aTimerActive = false;
         m_mmc5aTimerIrqFlag = false;
+        m_audioPcmLatched = false;
+        m_audioStatus = 0;
+        m_expQuarterCounter = 0;
+        m_expHalfCounter = 0;
+        m_expansionAudioSample = 0.0f;
+        for(int i = 0; i < 2; ++i) {
+            m_expPulse[i] = ExpansionPulseState();
+        }
+        memset(m_audioPulseRegs, 0, sizeof(m_audioPulseRegs));
         refreshChrMask();
     }
 
@@ -541,16 +706,20 @@ public:
         case 0x5000:
         case 0x5001:
         case 0x5002:
-        case 0x5003:
-            m_audioPulseRegs[0][absolute - 0x5000] = data;
+        case 0x5003: {
+            int reg = absolute - 0x5000;
+            writePulseRegister(0, reg, data);
             break;
+        }
 
         case 0x5004:
         case 0x5005:
         case 0x5006:
-        case 0x5007:
-            m_audioPulseRegs[1][absolute - 0x5004] = data;
+        case 0x5007: {
+            int reg = absolute - 0x5004;
+            writePulseRegister(1, reg, data);
             break;
+        }
 
         case 0x5010:
             m_audioPcmControl = data;
@@ -558,11 +727,17 @@ public:
 
         case 0x5011:
             m_audioPcmValue = data;
+            m_audioPcmLatched = true;
             break;
 
         case 0x5015:
-            m_audioStatus &= static_cast<uint8_t>(~0x03);
-            m_audioStatus |= static_cast<uint8_t>(data & 0x03);
+            m_audioStatus = static_cast<uint8_t>(data & 0x03);
+            if((m_audioStatus & 0x01) == 0) {
+                m_expPulse[0].lengthCounter = 0;
+            }
+            if((m_audioStatus & 0x02) == 0) {
+                m_expPulse[1].lengthCounter = 0;
+            }
             break;
 
         case 0x5100:
@@ -726,7 +901,9 @@ public:
 
         switch(absolute) {
         case 0x5015:
-            return m_audioStatus;
+            return static_cast<uint8_t>(
+                (m_expPulse[0].lengthCounter > 0 ? 0x01 : 0x00) |
+                (m_expPulse[1].lengthCounter > 0 ? 0x02 : 0x00));
 
         case 0x5204: {
             uint8_t ret = 0;
@@ -836,6 +1013,18 @@ public:
         SERIALIZEDATA(s, m_audioPcmControl);
         SERIALIZEDATA(s, m_audioPcmValue);
         SERIALIZEDATA(s, m_audioStatus);
+        SERIALIZEDATA(s, m_audioPcmLatched);
+        for(int i = 0; i < 2; ++i) {
+            SERIALIZEDATA(s, m_expPulse[i].timerCounter);
+            SERIALIZEDATA(s, m_expPulse[i].dutyStep);
+            SERIALIZEDATA(s, m_expPulse[i].lengthCounter);
+            SERIALIZEDATA(s, m_expPulse[i].envelopeDivider);
+            SERIALIZEDATA(s, m_expPulse[i].envelopeVolume);
+            SERIALIZEDATA(s, m_expPulse[i].envelopeStart);
+        }
+        SERIALIZEDATA(s, m_expQuarterCounter);
+        SERIALIZEDATA(s, m_expHalfCounter);
+        SERIALIZEDATA(s, m_expansionAudioSample);
         s.array(reinterpret_cast<uint8_t*>(m_mmc5aRegs), 1, static_cast<int>(sizeof(m_mmc5aRegs)));
         SERIALIZEDATA(s, m_mmc5aTimerCounter);
         SERIALIZEDATA(s, m_mmc5aTimerActive);
@@ -933,6 +1122,23 @@ public:
                 --m_mmc5aTimerCounter;
             }
         }
+
+        stepPulseTimer(0);
+        stepPulseTimer(1);
+
+        if(++m_expQuarterCounter >= 7457) {
+            m_expQuarterCounter -= 7457;
+            clockPulseEnvelope(0);
+            clockPulseEnvelope(1);
+        }
+
+        if(++m_expHalfCounter >= 14914) {
+            m_expHalfCounter -= 14914;
+            clockPulseLength(0);
+            clockPulseLength(1);
+        }
+
+        updateExpansionAudioSample();
     }
 
     GERANES_HOT void onPpuCycle(int scanline, int cycle, bool isRendering, bool isPreLine) override
@@ -1112,5 +1318,10 @@ public:
         }
 
         return m_cd.readChr<BankSize::B1K>(bank, effectiveAddr);
+    }
+
+    GERANES_HOT float getExpansionAudioSample() override
+    {
+        return m_expansionAudioSample;
     }
 };

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -112,7 +112,6 @@ private:
 
     std::array<uint8_t, 0x400> m_exRam = {};
     std::array<uint8_t, 0x400> m_mmc5aRam = {};
-    std::array<uint8_t, 0x10000> m_prgRam = {};
 
     GERANES_INLINE uint16_t pulsePeriod(int channel) const
     {
@@ -277,10 +276,15 @@ private:
         return (m_prgRamProtect1 & 0x03) == 0x02 && (m_prgRamProtect2 & 0x03) == 0x01;
     }
 
-    GERANES_INLINE uint8_t readPrgRam8k(uint8_t bank8k, int addr)
+    GERANES_INLINE int prgRamOffset(uint8_t bank8k, int addr) const
     {
         uint8_t bank = bank8k & 0x07;
-        return m_prgRam[(bank << log2(BankSize::B8K)) + (addr & (static_cast<int>(BankSize::B8K) - 1))];
+        return (bank << log2(BankSize::B8K)) + (addr & (static_cast<int>(BankSize::B8K) - 1));
+    }
+
+    GERANES_INLINE uint8_t readPrgRam8k(uint8_t bank8k, int addr)
+    {
+        return BaseMapper::readSaveRam(prgRamOffset(bank8k, addr));
     }
 
     GERANES_INLINE void writePrgRam8k(uint8_t bank8k, int addr, uint8_t data)
@@ -289,8 +293,7 @@ private:
             return;
         }
 
-        uint8_t bank = bank8k & 0x07;
-        m_prgRam[(bank << log2(BankSize::B8K)) + (addr & (static_cast<int>(BankSize::B8K) - 1))] = data;
+        BaseMapper::writeSaveRam(prgRamOffset(bank8k, addr), data);
     }
 
     GERANES_INLINE uint8_t readPrgRom8k(uint8_t bank8k, int addr)
@@ -983,7 +986,6 @@ public:
 
         s.array(m_exRam.data(), 1, static_cast<int>(m_exRam.size()));
         s.array(m_mmc5aRam.data(), 1, static_cast<int>(m_mmc5aRam.size()));
-        s.array(m_prgRam.data(), 1, static_cast<int>(m_prgRam.size()));
         refreshChrMask();
     }
 

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -1,10 +1,7 @@
 #pragma once
 
 #include <array>
-#include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <sstream>
 
 #include "BaseMapper.h"
 #include "../APU/APUCommon.h"
@@ -110,16 +107,6 @@ private:
     int16_t m_lineCounter = -2;
     uint16_t m_lastNtRead = 0xFFFF;
     uint8_t m_sameNtReadCount = 0;
-    bool m_lastSplitActiveLogged = false;
-    bool m_lastSplitStateValid = false;
-    uint16_t m_lastLoggedChrBank = 0xFFFF;
-    uint8_t m_lastLoggedChrPage = 0xFF;
-    bool m_traceInitDone = false;
-    bool m_traceEnabled = false;
-    bool m_traceChr = false;
-    uint32_t m_traceLines = 0;
-    std::ofstream m_traceFile;
-    static constexpr uint32_t TRACE_MAX_LINES = 200000;
 
     std::array<uint8_t, 0x400> m_exRam = {};
     std::array<uint8_t, 0x400> m_mmc5aRam = {};
@@ -269,47 +256,6 @@ private:
             n >>= 1;
         }
         return mask;
-    }
-
-    void initTraceIfNeeded()
-    {
-        if(m_traceInitDone) {
-            return;
-        }
-        m_traceInitDone = true;
-
-        const char* enabled = std::getenv("GERANES_MMC5_TRACE");
-        if(enabled == nullptr || enabled[0] == '0') {
-            return;
-        }
-
-        const char* path = std::getenv("GERANES_MMC5_TRACE_FILE");
-        if(path == nullptr || path[0] == '\0') {
-            path = "/tmp/geranes-mmc5-trace.log";
-        }
-
-        m_traceFile.open(path, std::ios::out | std::ios::trunc);
-        m_traceEnabled = m_traceFile.is_open();
-        const char* traceChr = std::getenv("GERANES_MMC5_TRACE_CHR");
-        m_traceChr = (traceChr != nullptr && traceChr[0] != '0');
-
-        if(m_traceEnabled) {
-            m_traceFile << "MMC5 trace start\n";
-            m_traceFile.flush();
-        }
-    }
-
-    void traceLine(const std::string& s)
-    {
-        initTraceIfNeeded();
-        if(!m_traceEnabled || m_traceLines >= TRACE_MAX_LINES) {
-            return;
-        }
-        m_traceFile << s << '\n';
-        ++m_traceLines;
-        if((m_traceLines & 0x3FF) == 0) {
-            m_traceFile.flush();
-        }
     }
 
     GERANES_INLINE uint8_t fillAttributeByte() const
@@ -558,7 +504,6 @@ public:
         m_lineCounter = -2;
         m_lastNtRead = 0xFFFF;
         m_sameNtReadCount = 0;
-        m_lastSplitStateValid = false;
         m_extAttrLatch = 0;
         m_splitAttrLatch = 0;
 
@@ -750,9 +695,6 @@ public:
             m_chrRamEnable = (data & 0x80) != 0;
             refreshChrMask();
             updateChrMaps();
-            traceLine(
-                "reg 5101 chrMode=" + std::to_string(m_chrMode) +
-                " chrRamEnable=" + std::to_string(m_chrRamEnable ? 1 : 0));
             break;
 
         case 0x5102:
@@ -765,7 +707,6 @@ public:
 
         case 0x5104:
             m_exRamMode = data & 0x03;
-            traceLine("reg 5104 exRamMode=" + std::to_string(m_exRamMode));
             break;
 
         case 0x5105:
@@ -773,12 +714,6 @@ public:
             m_nameTableMap[1] = (data >> 2) & 0x03;
             m_nameTableMap[2] = (data >> 4) & 0x03;
             m_nameTableMap[3] = (data >> 6) & 0x03;
-            traceLine(
-                "reg 5105 ntMap=" + std::to_string(data) +
-                " [" + std::to_string(m_nameTableMap[0]) +
-                "," + std::to_string(m_nameTableMap[1]) +
-                "," + std::to_string(m_nameTableMap[2]) +
-                "," + std::to_string(m_nameTableMap[3]) + "]");
             break;
 
         case 0x5106:
@@ -820,7 +755,6 @@ public:
             m_abMode = 0;
             m_chrSpriteRegs[absolute - 0x5120] = static_cast<uint16_t>(data | ((m_chrUpperBits & 0x03) << 8));
             updateChrMaps();
-            traceLine("reg " + std::to_string(absolute) + " chra[" + std::to_string(absolute - 0x5120) + "]=" + std::to_string(data));
             break;
 
         case 0x5128:
@@ -830,7 +764,6 @@ public:
             m_abMode = 1;
             m_chrBgRegs[absolute - 0x5128] = static_cast<uint16_t>(data | ((m_chrUpperBits & 0x03) << 8));
             updateChrMaps();
-            traceLine("reg " + std::to_string(absolute) + " chrb[" + std::to_string(absolute - 0x5128) + "]=" + std::to_string(data));
             break;
 
         case 0x5130:
@@ -869,17 +802,14 @@ public:
 
         case 0x5200:
             m_splitMode = data;
-            traceLine("reg 5200 splitMode=" + std::to_string(m_splitMode));
             break;
 
         case 0x5201:
             m_splitScroll = data;
-            traceLine("reg 5201 splitScroll=" + std::to_string(m_splitScroll));
             break;
 
         case 0x5202:
             m_splitBank = data;
-            traceLine("reg 5202 splitBank=" + std::to_string(m_splitBank));
             break;
         }
     }
@@ -1065,22 +995,11 @@ public:
     GERANES_HOT void setSpriteSize8x16(bool sprite8x16) override
     {
         m_sprite8x16 = sprite8x16;
-        traceLine(std::string("ppu sprite8x16=") + (m_sprite8x16 ? "1" : "0"));
-    }
-
-    GERANES_HOT void setPpuReadAffectsBus(bool affectsBus) override
-    {
-        (void)affectsBus;
     }
 
     GERANES_HOT void setPpuMask(uint8_t mask) override
     {
         bool newEnabled = (mask & 0x18) != 0;
-        traceLine(
-            "ppu mask=" + std::to_string(mask) +
-            " bg=" + std::to_string((mask & 0x08) ? 1 : 0) +
-            " spr=" + std::to_string((mask & 0x10) ? 1 : 0) +
-            " subs=" + std::to_string(newEnabled ? 1 : 0));
         m_substitutionsEnabled = newEnabled;
 
         // MMC5+ behavior (mirrors Nintendulator): when both BG and sprites are disabled,
@@ -1252,34 +1171,12 @@ public:
                 uint8_t shift = static_cast<uint8_t>(((tileY & 0x02) << 1) | (splitTileX & 0x02));
                 m_splitAttrLatch = expandPaletteBits(static_cast<uint8_t>((attrByte >> shift) & 0x03));
                 value = m_extAttrLatch;
-                if(fetchTileX == 0 || fetchTileX == 16 || fetchTileX == 31) {
-                    traceLine(
-                        "split nt idx=" + std::to_string(index) +
-                        " x=" + std::to_string(fetchTileX) +
-                        " y=" + std::to_string(m_splitScanline) +
-                        " ex=" + std::to_string(exAddr) +
-                        " exv=" + std::to_string(m_extAttrLatch));
-                }
             }
             else {
                 m_extAttrLatch = m_exRam[addr & 0x03FF];
                 m_splitAttrLatch = 0;
             }
 
-            if(splitEnabled && (!m_lastSplitStateValid || m_lastSplitActiveLogged != m_splitActive)) {
-                m_lastSplitStateValid = true;
-                m_lastSplitActiveLogged = m_splitActive;
-                traceLine(
-                    "split state active=" + std::to_string(m_splitActive ? 1 : 0) +
-                    " mode=" + std::to_string(m_splitMode) +
-                    " x=" + std::to_string(fetchTileX) +
-                    " nt=" + std::to_string(index));
-            }
-        }
-        else {
-            if(m_splitMode & 0x80) {
-                m_lastSplitStateValid = false;
-            }
         }
 
         if(!m_isSpriteFetch && m_renderingEnabled && m_substitutionsEnabled && addr >= 0x03C0 && m_splitActive && (m_splitMode & 0x80)) {
@@ -1298,20 +1195,6 @@ public:
     {
         int effectiveAddr = applySplitPatternRow(addr);
         uint16_t bank = resolveChr1kBank(effectiveAddr);
-        uint8_t page = static_cast<uint8_t>((effectiveAddr >> 10) & 0x07);
-
-        if(m_traceChr && (page != m_lastLoggedChrPage || bank != m_lastLoggedChrBank)) {
-            m_lastLoggedChrPage = page;
-            m_lastLoggedChrBank = bank;
-            traceLine(
-                "chr page=" + std::to_string(page) +
-                " bank=" + std::to_string(bank) +
-                " mode=" + std::to_string(m_chrMode) +
-                " spr=" + std::to_string(m_isSpriteFetch ? 1 : 0) +
-                " spr8x16=" + std::to_string(m_sprite8x16 ? 1 : 0) +
-                " exMode=" + std::to_string(m_exRamMode) +
-                " split=" + std::to_string(m_splitActive ? 1 : 0));
-        }
 
         if(useChrRam()) {
             return readChrRam<BankSize::B1K>(bank, effectiveAddr);

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -19,7 +19,7 @@
 // - Expansion audio (2 pulse channels + PCM DAC) ($5000-$5015)
 class Mapper005 : public BaseMapper
 {
-private: // GERA VIADÃO!!!!!!!
+private:
     uint8_t m_prgMode = 3;
     uint8_t m_chrMode = 3;
     uint8_t m_chrModeByte = 3;

--- a/src/GeraNES/Mappers/Mapper005.h
+++ b/src/GeraNES/Mappers/Mapper005.h
@@ -1138,30 +1138,34 @@ public:
         int tileNumber = static_cast<int>(m_splitTileCount);
         uint8_t splitTileX = 0;
         if(isNtFetch) {
+            // Split/ex-attribute logic must follow BG nametable fetches only.
+            // Sprite-phase dummy nametable reads would skew the tile counter.
+            if(m_isSpriteFetch) {
+                return value;
+            }
+
             ++m_splitTileCount;
             tileNumber = static_cast<int>(m_splitTileCount);
 
             if(splitEnabled) {
                 // MMC5 split region follows nametable fetch order with a +2 pipeline offset.
-                uint8_t column = static_cast<uint8_t>((tileNumber + 2) % 42);
+                int fetchIndex = tileNumber - 1; // 0..33 (32 visible + 2 prefetch)
+                uint8_t column = static_cast<uint8_t>((fetchIndex + 2) % 34);
                 bool splitRight = (m_splitMode & 0x40) != 0;
                 uint8_t threshold = m_splitMode & 0x1F;
+                bool visibleColumn = column < 32;
 
-                if(column == 0) {
-                    m_splitActive = !splitRight;
+                if(splitRight) {
+                    m_splitActive = visibleColumn && (column >= threshold);
                 }
-
-                if(column == threshold && tileNumber < 42) {
-                    m_splitActive = !m_splitActive;
-                }
-                else if(column > 32) {
-                    m_splitActive = false;
+                else {
+                    m_splitActive = visibleColumn && (column < threshold);
                 }
 
                 splitTileX = static_cast<uint8_t>(column & 0x1F);
 
                 uint8_t splitY = m_splitScanline;
-                if(tileNumber >= 41) {
+                if(fetchIndex >= 32) {
                     splitY = static_cast<uint8_t>((splitY + 1) % 240);
                 }
                 m_splitVScroll = static_cast<uint8_t>((splitY + m_splitScroll) % 240);
@@ -1183,7 +1187,7 @@ public:
             }
 
             // ExRAM mode 1 pipeline: NT fetch arms AT+CHR substitution for this tile.
-            if(!m_isSpriteFetch && m_exRamMode == 1 && (tileNumber <= 32 || tileNumber >= 40) && !m_splitActive) {
+            if(!m_isSpriteFetch && m_exRamMode == 1 && !m_splitActive) {
                 m_extAttrLatch = m_exRam[addr & 0x03FF];
                 m_exAttrSelectedChrBank = static_cast<uint16_t>(((m_chrUpperBits & 0x03) << 6) | (m_extAttrLatch & 0x3F));
                 m_exAttrFetchCounter = 3;

--- a/src/GeraNES/NesCartridgeData/DbOverwriteCartridgeData.h
+++ b/src/GeraNES/NesCartridgeData/DbOverwriteCartridgeData.h
@@ -81,7 +81,7 @@ public:
 
         m_system = m_item->System != GameDatabase::Sistem::Unknown ? m_item->System : m_src->sistem();
 
-        m_inputType = m_item->InputType != GameDatabase::InputType::Unspecified ? m_item->InputType : m_src->inputType();
+        m_inputType = m_item->InputDeviceType != GameDatabase::InputType::Unspecified ? m_item->InputDeviceType : m_src->inputType();
     }
 
     virtual ~DbOverwriteCartridgeData() {

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -166,6 +166,8 @@ private:
 
     uint16_t m_busAddress;
     int m_updateA12Delay;
+    bool m_isSpritePatternFetch;
+    bool m_currentReadAffectsBus;
 
 
     //Do not serialize variables below
@@ -204,6 +206,13 @@ private:
     template<bool writeFlag, bool affectsTheBus>
     GERANES_HOT auto readWritePpuMemory(uint16_t addr, uint8_t data = 0) -> std::conditional_t<writeFlag, void, uint8_t>
     {
+        m_currentReadAffectsBus = affectsTheBus;
+        m_cartridge.setPpuReadAffectsBus(affectsTheBus);
+
+        if constexpr(!writeFlag && affectsTheBus) {
+            m_cartridge.onPpuRead(addr & 0x3FFF);
+        }
+
         if constexpr (affectsTheBus)
             setBusAddress(addr);
 
@@ -211,6 +220,7 @@ private:
 
         if(addr < 0x2000)
         {
+            m_cartridge.setPpuFetchSource(m_isSpritePatternFetch);
             if constexpr(writeFlag) m_cartridge.writeChr(addr,data);
             else return m_cartridge.readChr(addr);
         }
@@ -265,6 +275,11 @@ private:
     //index 0-3
     GERANES_INLINE_HOT void writeNameTable(uint8_t addrIndex, uint16_t addr, uint8_t data)
     {
+        if(m_cartridge.useCustomNameTable(addrIndex&0x03)) {
+            m_cartridge.writeCustomNameTable(addrIndex&0x03, addr&0x3FF, data);
+            return;
+        }
+
         int index = m_cartridge.mirroring(addrIndex&0x03);
         m_nameTable[index&3][addr&0x3FF] = data;
     }
@@ -272,12 +287,21 @@ private:
     //index 0-3
     GERANES_INLINE_HOT uint8_t readNameTable(uint8_t addrIndex, uint16_t addr)
     {
+        uint8_t ret = 0;
+
         if(m_cartridge.useCustomNameTable(addrIndex&0x03)) {
-            return m_cartridge.readCustomNameTable(addrIndex&0x03,addr&0x3FF);
+            ret = m_cartridge.readCustomNameTable(addrIndex&0x03,addr&0x3FF);
+        }
+        else {
+            int index = m_cartridge.mirroring(addrIndex&0x03);
+            ret = m_nameTable[index&3][addr&0x3FF];
         }
 
-        int index = m_cartridge.mirroring(addrIndex&0x03);
-        return m_nameTable[index&3][addr&0x3FF];
+        if(!m_currentReadAffectsBus) {
+            return ret;
+        }
+
+        return m_cartridge.transformNameTableRead(addrIndex&0x03, addr&0x3FF, ret);
     }
 
     GERANES_INLINE void setBusAddress(uint16_t addr) {
@@ -376,6 +400,8 @@ public:
 
         m_busAddress = 0;
         m_updateA12Delay = 0;
+        m_isSpritePatternFetch = false;
+        m_currentReadAffectsBus = true;
 
         updateSettings();        
 
@@ -451,6 +477,7 @@ public:
     template<bool writeFlag>
     GERANES_INLINE_HOT uint8_t readWrite(int addr, uint8_t data)
     {
+        const int fullAddr = addr;
         uint8_t openBusMask;
 
         if constexpr(!writeFlag) {
@@ -467,18 +494,18 @@ public:
         {
         case 0x2000: //acess: write only
         {
-            if constexpr(writeFlag) writePPUCTRL(data);
+            if constexpr(writeFlag) writePPUCTRL(data, true);
             break;
         }
         case 0x2001: //acess: write only
         {
-            if constexpr(writeFlag) writePPUMASK(data);
+            if constexpr(writeFlag) writePPUMASK(data, fullAddr == 0x2001);
             break;
         }
         case 0x2002: //acess: read only
         {
             if constexpr(!writeFlag) {
-                data = readPPUSTATUS();
+                data = readPPUSTATUS(fullAddr == 0x2002);
 
                 data &= ~0x1F;
                 data |= m_openBus&0x1F; //the low 5 bits are open and they should be from decay value
@@ -845,6 +872,7 @@ yyy NN YYYYY XXXXX
 
                 int index = spriteIndexInPatternTable + (m_sprite8x8PatternTableAddress?256:0); //add 512 if sprite is in second page (0x1000);
 
+                m_isSpritePatternFetch = true;
                 paletteIndex =  getColorLowBitsInPatternTable(index,spriteXToDraw,spriteLineToDraw);
                 paletteIndex |= (spriteAttrib&0x03) << 2; //get 2 high bits
             }
@@ -874,6 +902,7 @@ yyy NN YYYYY XXXXX
 
                 if(spriteIndexInPatternTable&0x01) index += 255;
 
+                m_isSpritePatternFetch = true;
                 paletteIndex = getColorLowBitsInPatternTable(index,spriteXToDraw,spriteLineToDraw%8);
                 paletteIndex |= (spriteAttrib&0x03) << 2; //get 2 high bits
             }
@@ -987,6 +1016,7 @@ yyy NN YYYYY XXXXX
     GERANES_HOT void ppuCycle()
     {        
         if(m_cycle == 0) onScanlineStart();
+        m_cartridge.onPpuCycle(m_scanline, m_cycle, m_renderLine && m_prevCycleRenderingEnabled, m_preLine);
 
         if(!m_interruptFlag) {
             if(m_VBlankHasStarted && m_NMIOnVBlank) {
@@ -1101,6 +1131,8 @@ yyy NN YYYYY XXXXX
     }
 
     void fetchSprites() {
+        // Mapper hooks must classify sprite-cycle PPU reads as sprite-source.
+        m_isSpritePatternFetch = true;
 
         const int startCycle = 257;
 
@@ -1188,6 +1220,7 @@ yyy NN YYYYY XXXXX
     //in pixels 512x480
     uint8_t getColorLowBitsInNameTables(int x, int y)
     {
+        m_isSpritePatternFetch = false;
         const int tileX = x >> 3; //x/8
         const int tileY = y >> 3; //y/8
 
@@ -1253,7 +1286,7 @@ yyy NN YYYYY XXXXX
         return color;
     }
     
-    GERANES_INLINE void writePPUCTRL(uint8_t data)
+    GERANES_INLINE void writePPUCTRL(uint8_t data, bool notifyMapper = true)
     {
         //put base nametable address in bits 10 and 11 of reg_t
         m_reg_t &= 0xF3FF;
@@ -1263,6 +1296,9 @@ yyy NN YYYYY XXXXX
         m_sprite8x8PatternTableAddress = (data&0x08) ? true : false;
         m_backgroundPatternTableAddress = (data&0x10) ? true : false;
         m_spriteSize8x16 = (data&0x20) ? true : false;
+        if(notifyMapper) {
+            m_cartridge.setSpriteSize8x16(m_spriteSize8x16);
+        }
         m_PPUSlave = (data&0x40) ? true : false;
         m_NMIOnVBlank = (data&0x80) ? true : false;
 
@@ -1270,7 +1306,7 @@ yyy NN YYYYY XXXXX
 
     }
 
-    GERANES_INLINE void writePPUMASK(uint8_t data)
+    GERANES_INLINE void writePPUMASK(uint8_t data, bool notifyMapper = true)
     {
         m_monochromeDisplay = (data&0x01) ? true : false;
         m_showBackgroundLeftmost8Pixels = (data&0x02) ? true : false;
@@ -1278,19 +1314,25 @@ yyy NN YYYYY XXXXX
         m_backgroundEnabled = (data&0x08) ? true : false;
         m_spritesEnabled = (data&0x10) ? true : false;
         m_colorEmphasis = data >> 5;        
+        if(notifyMapper) {
+            m_cartridge.setPpuMask(data);
+        }
 
         if(m_renderingEnabled != (m_backgroundEnabled || m_spritesEnabled)) {
 		    m_needUpdateState = true;
 	    }
     }
 
-    GERANES_INLINE uint8_t readPPUSTATUS()
+    GERANES_INLINE uint8_t readPPUSTATUS(bool notifyMapper = true)
     {
         uint8_t ret = 0x00;
 
         m_lastPPUSTATUSReadCycle = m_cycle;
 
         if(m_VBlankHasStarted) ret |= 0x80;
+        if(notifyMapper) {
+            m_cartridge.onPpuStatusRead((ret & 0x80) != 0);
+        }
 
         if(m_sprite0Hit) ret |= 0x40;
         if(m_spriteOverflow) ret |= 0x20;
@@ -1330,7 +1372,15 @@ yyy NN YYYYY XXXXX
     GERANES_INLINE bool isRenderingEnabled() {
         //return m_spritesEnabled || m_backgroundEnabled;
         return m_renderingEnabled;
-    }    
+    }
+
+    GERANES_INLINE bool isActivelyRendering() {
+        return m_renderLine && m_renderingEnabled;
+    }
+
+    GERANES_INLINE int scanline() const {
+        return m_scanline;
+    }
 
     GERANES_INLINE void writeOAMDATA(uint8_t data)
     {
@@ -1647,6 +1697,8 @@ yyy NNYY YYYX XXXX
     }
 
     GERANES_INLINE void fetchNameTableByte() {
+        // Background tile fetch source for mapper CHR/NT substitution.
+        m_isSpritePatternFetch = false;
         uint16_t address = getNameTableAddr();
         uint8_t tileIndex = readPpuMemory(address);
 
@@ -1662,6 +1714,8 @@ yyy NNYY YYYX XXXX
     }
 
     GERANES_INLINE void fetchAttributeTableByte() {
+        // Background tile fetch source for mapper CHR/NT substitution.
+        m_isSpritePatternFetch = false;
 
         int address = getAttributeTableAddr();
         int shift = ((m_reg_v >> 4) & 4) | (m_reg_v & 2);
@@ -1669,10 +1723,12 @@ yyy NNYY YYYX XXXX
     }
 
     GERANES_INLINE void fetchLowTileByte() {
+        m_isSpritePatternFetch = false;
         m_lowTileByte = readPpuMemory(m_tileAddr);        
     }
 
     GERANES_INLINE void fetchHighTileByte() {
+        m_isSpritePatternFetch = false;
         m_highTileByte = readPpuMemory(m_tileAddr + 8);        
     }
 
@@ -1791,6 +1847,8 @@ yyy NNYY YYYX XXXX
 
         SERIALIZEDATA(s, m_busAddress);
         SERIALIZEDATA(s, m_updateA12Delay);
+        SERIALIZEDATA(s, m_isSpritePatternFetch);
+        SERIALIZEDATA(s, m_currentReadAffectsBus);
 
         m_pFrameBuffer = &m_framebuffer[m_currentY*SCREEN_WIDTH+m_currentX];
     }

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -116,6 +116,16 @@ private:
 
     uint8_t m_spritesIndexesInThisLine[64];
 
+    struct SpriteFetchEntry {
+        uint8_t x;
+        uint8_t attr;
+        uint8_t lowByte;
+        uint8_t highByte;
+        bool sprite0;
+    };
+    SpriteFetchEntry m_spriteFetchEntries[8];
+    uint8_t m_spriteFetchCount;
+
     //write/read internal regs
     uint16_t m_reg_v;
     uint8_t m_reg_x;
@@ -340,6 +350,8 @@ public:
 
         m_spritesInThisLine = 0;
         m_testSprite0HitInThisLine = false;
+        m_spriteFetchCount = 0;
+        memset(m_spriteFetchEntries, 0, sizeof(m_spriteFetchEntries));
 
         m_oamAddr = 0;
         m_dataLatch = 0;
@@ -811,123 +823,39 @@ yyy NN YYYYY XXXXX
         if(!m_showSpritesLeftmost8Pixels && m_currentX < 8) return;
         if(m_currentY == 0) return;
 
-        int spriteLineToDraw = 0;
-        int spriteXToDraw = 0;
-
         int paletteIndex = 0;
         bool isPixelBehind = false;
 
-        bool spritesAsMask = false;
+        for(int i = 0; i < m_spriteFetchCount; i++) {
+            const SpriteFetchEntry& sprite = m_spriteFetchEntries[i];
 
-        if(m_settings.spriteLimitDisabled() && m_spritesInThisLine >= 8) {
-            
-            // Detecting masking effects
-            // Games will place 8 consecutive sprites with the same Y coordinate and same tile number.
-            // If you see this, then that is a sign that the game is using a masking effect,
-            // and the 8-sprite limit should be enforced for that area.
-
-            const Sprite* first = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[0]];
- 
-
-            int i = 1;
-
-            //test if all sprites have the same y and x
-            for(; i < 8; i++) {
-                const Sprite* other = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[i]];
-
-
-                if(first->y != other->y && first->indexInPatternTable != other->indexInPatternTable) break;
+            if(m_currentX < sprite.x || m_currentX >= sprite.x + 8) {
+                continue;
             }
 
-            spritesAsMask = i == 8;
-        }
-
-        for(int i = 0; i < m_spritesInThisLine; i++)
-        {
-            const Sprite* sprite = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[i]];
-
-            const int& spriteY = sprite->y+1;
-            const uint8_t& spriteIndexInPatternTable = sprite->indexInPatternTable;
-            const uint8_t& spriteAttrib = sprite->attrib;
-            const int& spriteX = sprite->x;
-
-            if(i >= 8 && (!m_settings.spriteLimitDisabled() || spritesAsMask)) break;
-
-            //if( !(m_currentX >= spriteX && m_currentX < spriteX+8) ) continue;
-            if( m_currentX < spriteX || m_currentX >= spriteX+8) continue;
-
-            if(m_spriteSize8x16 == false) //sprite 8x8
-            {
-
-                if( (spriteAttrib&0x80) == false) //vertical flip = false?
-                    spriteLineToDraw = m_currentY - spriteY;
-                else
-                    spriteLineToDraw = spriteY - m_currentY + 7;
-
-                if( (spriteAttrib&0x40) == false) //horizontal flip = false?
-                    spriteXToDraw = m_currentX - spriteX;
-                else
-                    spriteXToDraw = spriteX - m_currentX + 7;
-
-                int index = spriteIndexInPatternTable + (m_sprite8x8PatternTableAddress?256:0); //add 512 if sprite is in second page (0x1000);
-
-                m_isSpritePatternFetch = true;
-                paletteIndex =  getColorLowBitsInPatternTable(index,spriteXToDraw,spriteLineToDraw);
-                paletteIndex |= (spriteAttrib&0x03) << 2; //get 2 high bits
-            }
-            else //sprite 8x16
-            {
-                if( (spriteAttrib&0x80) == false) //vertical flip check
-                    spriteLineToDraw = m_currentY - spriteY;
-                else
-                    spriteLineToDraw = spriteY - m_currentY + 15;
-
-                if( (spriteAttrib&0x40) == false) //horizontal flip = false?
-                    spriteXToDraw = m_currentX - spriteX;
-                else
-                    spriteXToDraw = spriteX - m_currentX + 7;
-
-                int index;
-
-                if(spriteLineToDraw < 8) //top sprite
-                {
-                    index = spriteIndexInPatternTable;
-                }
-                else //bottom sprite
-                {
-                    index = spriteIndexInPatternTable;
-                    index += 1;
-                }
-
-                if(spriteIndexInPatternTable&0x01) index += 255;
-
-                m_isSpritePatternFetch = true;
-                paletteIndex = getColorLowBitsInPatternTable(index,spriteXToDraw,spriteLineToDraw%8);
-                paletteIndex |= (spriteAttrib&0x03) << 2; //get 2 high bits
+            int pixelX = m_currentX - sprite.x;
+            int bit = (sprite.attr & 0x40) ? pixelX : (7 - pixelX);
+            int color = ((sprite.lowByte >> bit) & 0x01) | (((sprite.highByte >> bit) & 0x01) << 1);
+            if(color == 0) {
+                continue;
             }
 
-            //sprite0hit test
-            if (i == 0 && m_testSprite0HitInThisLine && m_backgroundEnabled &&
-            (m_currentPixelColorIndex&0x03) != 0 &&
-            (paletteIndex&0x03) != 0 && m_currentX != 255) {
+            paletteIndex = color | ((sprite.attr & 0x03) << 2);
+
+            if(sprite.sprite0 && m_backgroundEnabled &&
+               (m_currentPixelColorIndex & 0x03) != 0 &&
+               (paletteIndex & 0x03) != 0 && m_currentX != 255) {
                 m_sprite0Hit = true;
             }
 
-            if( (paletteIndex&0x03) != 0)
-            {
-                paletteIndex = 0x10+paletteIndex;
-                isPixelBehind = spriteAttrib&0x20;
-                break;
-            }
-
+            paletteIndex = 0x10 + paletteIndex;
+            isPixelBehind = (sprite.attr & 0x20) != 0;
+            break;
         }
 
-        if( (paletteIndex&0x03) != 0 )
-        {
-            if( (m_currentPixelColorIndex&0x03) == 0) m_currentPixelColorIndex = paletteIndex;
-            else
-            {
-                if(!isPixelBehind) m_currentPixelColorIndex = paletteIndex;
+        if((paletteIndex & 0x03) != 0) {
+            if((m_currentPixelColorIndex & 0x03) == 0 || !isPixelBehind) {
+                m_currentPixelColorIndex = static_cast<uint8_t>(paletteIndex);
             }
         }
     }
@@ -1129,38 +1057,89 @@ yyy NN YYYYY XXXXX
         if(m_needUpdateState) updateState();
     }
 
+    GERANES_INLINE uint16_t getSpritePatternAddress(const Sprite& sprite, bool highPlane)
+    {
+        const int spriteHeight = m_spriteSize8x16 ? 16 : 8;
+        int spriteScanline = m_scanline + 1;
+        if(spriteScanline >= FRAME_NUMBER_OF_LINES) {
+            spriteScanline = 0;
+        }
+
+        int row = spriteScanline - (static_cast<int>(sprite.y) + 1);
+        if(row < 0 || row >= spriteHeight) {
+            return 0;
+        }
+
+        if(sprite.attrib & 0x80) {
+            row = (spriteHeight - 1) - row;
+        }
+
+        uint16_t base = 0;
+        uint16_t tileIndex = sprite.indexInPatternTable;
+        if(m_spriteSize8x16) {
+            base = (sprite.indexInPatternTable & 0x01) ? 0x1000 : 0x0000;
+            tileIndex = static_cast<uint16_t>(sprite.indexInPatternTable & 0xFE);
+            if(row >= 8) {
+                tileIndex++;
+                row -= 8;
+            }
+        }
+        else {
+            base = m_sprite8x8PatternTableAddress ? 0x1000 : 0x0000;
+        }
+
+        return static_cast<uint16_t>(base + (tileIndex << 4) + row + (highPlane ? 8 : 0));
+    }
+
     void fetchSprites() {
         // Mapper hooks must classify sprite-cycle PPU reads as sprite-source.
         m_isSpritePatternFetch = true;
+        m_cartridge.setPpuFetchSource(true);
 
         const int startCycle = 257;
+        const int spriteIndex = (m_cycle - startCycle) / 8;
 
-        int fetchCycle = (m_cycle - startCycle) % 8;   
+        if(m_cycle == startCycle) {
+            m_spriteFetchCount = 0;
+            memset(m_spriteFetchEntries, 0, sizeof(m_spriteFetchEntries));
+        }
+
+        int fetchCycle = (m_cycle - startCycle) % 8;
+        if(spriteIndex < 0 || spriteIndex >= 8) {
+            return;
+        }
+
+        Sprite* sprite = (Sprite*)&m_secondaryOam[spriteIndex << 2];
+        SpriteFetchEntry& entry = m_spriteFetchEntries[spriteIndex];
+        entry.x = sprite->x;
+        entry.attr = sprite->attrib;
+        entry.sprite0 = (spriteIndex == 0) && m_testSprite0HitInThisLine;
 
         switch(fetchCycle) {
 
             case 0: readPpuMemory(getNameTableAddr()); break;
             case 2: readPpuMemory(getAttributeTableAddr()); break;
-            case 4: {         
-
-                bool state;
-
-                int spriteIndex = (m_cycle - startCycle) / 8;
-                Sprite* sprite = (Sprite*)&m_secondaryOam[spriteIndex << 2];
-
-                uint8_t tile = sprite->indexInPatternTable;
-               
-                if(m_spriteSize8x16) {
-                    state = tile & 1;
+            case 4:
+                if(sprite->y == 0xFF) {
+                    entry.lowByte = 0;
+                    readPpuMemory(0);
                 }
-                else state = m_sprite8x8PatternTableAddress;
-
-                setBusAddress(m_busAddress | (state ? 0x1000 : 0)); // approximate relevant behavior         
-
+                else {
+                    entry.lowByte = readPpuMemory(getSpritePatternAddress(*sprite, false));
+                }
                 break;
-            }
+            case 6:
+                if(sprite->y == 0xFF) {
+                    entry.highByte = 0;
+                    readPpuMemory(0);
+                }
+                else {
+                    entry.highByte = readPpuMemory(getSpritePatternAddress(*sprite, true));
+                    m_spriteFetchCount = static_cast<uint8_t>(spriteIndex + 1);
+                }
+                break;
         }
-   
+    
     }
 
     //name tables
@@ -1698,6 +1677,7 @@ yyy NNYY YYYX XXXX
     GERANES_INLINE void fetchNameTableByte() {
         // Background tile fetch source for mapper CHR/NT substitution.
         m_isSpritePatternFetch = false;
+        m_cartridge.setPpuFetchSource(false);
         uint16_t address = getNameTableAddr();
         uint8_t tileIndex = readPpuMemory(address);
 
@@ -1715,6 +1695,7 @@ yyy NNYY YYYX XXXX
     GERANES_INLINE void fetchAttributeTableByte() {
         // Background tile fetch source for mapper CHR/NT substitution.
         m_isSpritePatternFetch = false;
+        m_cartridge.setPpuFetchSource(false);
 
         int address = getAttributeTableAddr();
         int shift = ((m_reg_v >> 4) & 4) | (m_reg_v & 2);
@@ -1805,6 +1786,8 @@ yyy NNYY YYYX XXXX
         s.array(m_palette, 1, sizeof(m_palette));
         s.array(m_primaryOam, 1, sizeof(m_primaryOam));
         s.array(m_secondaryOam, 1, sizeof(m_secondaryOam));
+        s.array(reinterpret_cast<uint8_t*>(m_spriteFetchEntries), 1, sizeof(m_spriteFetchEntries));
+        SERIALIZEDATA(s, m_spriteFetchCount);
 
         SERIALIZEDATA(s, m_reg_v);
         SERIALIZEDATA(s, m_reg_x);

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -1109,18 +1109,24 @@ yyy NN YYYYY XXXXX
             return;
         }
 
+        int fetchedSpriteCount = static_cast<int>(m_secondaryOamAddr >> 2);
+        if(fetchedSpriteCount > 8) {
+            fetchedSpriteCount = 8;
+        }
+        bool hasSpriteData = spriteIndex < fetchedSpriteCount;
+
         Sprite* sprite = (Sprite*)&m_secondaryOam[spriteIndex << 2];
         SpriteFetchEntry& entry = m_spriteFetchEntries[spriteIndex];
-        entry.x = sprite->x;
-        entry.attr = sprite->attrib;
-        entry.sprite0 = (spriteIndex == 0) && m_testSprite0HitInThisLine;
+        entry.x = hasSpriteData ? sprite->x : 0xFF;
+        entry.attr = hasSpriteData ? sprite->attrib : 0;
+        entry.sprite0 = hasSpriteData && (spriteIndex == 0) && m_testSprite0HitInThisLine;
 
         switch(fetchCycle) {
 
             case 0: readPpuMemory(getNameTableAddr()); break;
             case 2: readPpuMemory(getAttributeTableAddr()); break;
             case 4:
-                if(sprite->y == 0xFF) {
+                if(!hasSpriteData || sprite->y == 0xFF) {
                     entry.lowByte = 0;
                     readPpuMemory(0);
                 }
@@ -1129,7 +1135,7 @@ yyy NN YYYYY XXXXX
                 }
                 break;
             case 6:
-                if(sprite->y == 0xFF) {
+                if(!hasSpriteData || sprite->y == 0xFF) {
                     entry.highByte = 0;
                     readPpuMemory(0);
                 }

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -1126,7 +1126,17 @@ yyy NN YYYYY XXXXX
             case 0: readPpuMemory(getNameTableAddr()); break;
             case 2: readPpuMemory(getAttributeTableAddr()); break;
             case 4:
-                // Preserve the old approximate A12 behavior used by MMC3 IRQ timing.
+                if(!hasSpriteData || sprite->y == 0xFF) {
+                    entry.lowByte = 0;
+                    readPpuMemory(0);
+                }
+                else {
+                    entry.lowByte = readPpuMemory(getSpritePatternAddress(*sprite, false));
+                }
+
+                // Preserve old approximate A12 behavior used by MMC3 IRQ timing.
+                // This must happen after readPpuMemory(), otherwise that call overwrites
+                // the pending delayed A12 state for this cycle.
                 {
                     bool a12High = false;
                     if(m_spriteSize8x16) {
@@ -1136,15 +1146,6 @@ yyy NN YYYYY XXXXX
                         a12High = m_sprite8x8PatternTableAddress;
                     }
                     setBusAddress(static_cast<uint16_t>(m_busAddress | (a12High ? 0x1000 : 0x0000)));
-                    m_cartridge.setA12State(a12High);
-                }
-
-                if(!hasSpriteData || sprite->y == 0xFF) {
-                    entry.lowByte = 0;
-                    readPpuMemory(0);
-                }
-                else {
-                    entry.lowByte = readPpuMemory(getSpritePatternAddress(*sprite, false));
                 }
                 break;
             case 6:

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -818,6 +818,29 @@ yyy NN YYYYY XXXXX
 
     }    
 
+    GERANES_INLINE uint8_t getSpritePixelFake(const Sprite* sprite, int xOnScreen)
+    {
+        int spriteY = sprite->y + 1;
+        int spriteLineToDraw;
+        int spriteXToDraw;
+
+        if((sprite->attrib & 0x80) == 0) spriteLineToDraw = m_currentY - spriteY;
+        else spriteLineToDraw = (m_spriteSize8x16 ? 15 : 7) - (m_currentY - spriteY);
+
+        if((sprite->attrib & 0x40) == 0) spriteXToDraw = xOnScreen - sprite->x;
+        else spriteXToDraw = sprite->x - xOnScreen + 7;
+
+        if(!m_spriteSize8x16) {
+            int index = sprite->indexInPatternTable + (m_sprite8x8PatternTableAddress ? 256 : 0);
+            return (uint8_t)(getColorLowBitsInPatternTable(index, spriteXToDraw, spriteLineToDraw) | ((sprite->attrib & 0x03) << 2));
+        }
+
+        int index = sprite->indexInPatternTable;
+        if(spriteLineToDraw >= 8) index++;
+        if(sprite->indexInPatternTable & 0x01) index += 255;
+        return (uint8_t)(getColorLowBitsInPatternTable(index, spriteXToDraw, spriteLineToDraw & 0x07) | ((sprite->attrib & 0x03) << 2));
+    }
+
     GERANES_INLINE_HOT void renderSpritesPixel()
     {
         if(!m_showSpritesLeftmost8Pixels && m_currentX < 8) return;
@@ -825,32 +848,64 @@ yyy NN YYYYY XXXXX
 
         int paletteIndex = 0;
         bool isPixelBehind = false;
+        const int indexedSpritesCount = (m_spritesInThisLine > 64) ? 64 : m_spritesInThisLine;
 
-        for(int i = 0; i < m_spriteFetchCount; i++) {
-            const SpriteFetchEntry& sprite = m_spriteFetchEntries[i];
-
-            if(m_currentX < sprite.x || m_currentX >= sprite.x + 8) {
-                continue;
+        bool spritesAsMask = false;
+        if(m_settings.spriteLimitDisabled() && indexedSpritesCount >= 8) {
+            const Sprite* first = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[0]];
+            int i = 1;
+            for(; i < 8; i++) {
+                const Sprite* other = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[i]];
+                if(first->y != other->y && first->indexInPatternTable != other->indexInPatternTable) break;
             }
+            spritesAsMask = i == 8;
+        }
 
-            int pixelX = m_currentX - sprite.x;
-            int bit = (sprite.attr & 0x40) ? pixelX : (7 - pixelX);
-            int color = ((sprite.lowByte >> bit) & 0x01) | (((sprite.highByte >> bit) & 0x01) << 1);
-            if(color == 0) {
-                continue;
+        int maxSprites = indexedSpritesCount;
+        if(!m_settings.spriteLimitDisabled() || spritesAsMask) {
+            if(maxSprites > 8) maxSprites = 8;
+        }
+
+        for(int i = 0; i < maxSprites; i++) {
+            if(i < 8) {
+                if(i >= m_spriteFetchCount) continue;
+
+                const SpriteFetchEntry& sprite = m_spriteFetchEntries[i];
+
+                if(m_currentX < sprite.x || m_currentX >= sprite.x + 8) {
+                    continue;
+                }
+
+                int pixelX = m_currentX - sprite.x;
+                int bit = (sprite.attr & 0x40) ? pixelX : (7 - pixelX);
+                int color = ((sprite.lowByte >> bit) & 0x01) | (((sprite.highByte >> bit) & 0x01) << 1);
+                if(color == 0) {
+                    continue;
+                }
+
+                paletteIndex = color | ((sprite.attr & 0x03) << 2);
+
+                if(sprite.sprite0 && m_backgroundEnabled &&
+                   (m_currentPixelColorIndex & 0x03) != 0 &&
+                   (paletteIndex & 0x03) != 0 && m_currentX != 255) {
+                    m_sprite0Hit = true;
+                }
+
+                paletteIndex = 0x10 + paletteIndex;
+                isPixelBehind = (sprite.attr & 0x20) != 0;
+                break;
             }
+            else {
+                const Sprite* sprite = (Sprite*)&m_primaryOam[m_spritesIndexesInThisLine[i]];
+                if(m_currentX < sprite->x || m_currentX >= sprite->x + 8) continue;
 
-            paletteIndex = color | ((sprite.attr & 0x03) << 2);
+                uint8_t low = getSpritePixelFake(sprite, m_currentX);
+                if((low & 0x03) == 0) continue;
 
-            if(sprite.sprite0 && m_backgroundEnabled &&
-               (m_currentPixelColorIndex & 0x03) != 0 &&
-               (paletteIndex & 0x03) != 0 && m_currentX != 255) {
-                m_sprite0Hit = true;
+                paletteIndex = 0x10 + low;
+                isPixelBehind = (sprite->attrib & 0x20) != 0;
+                break;
             }
-
-            paletteIndex = 0x10 + paletteIndex;
-            isPixelBehind = (sprite.attr & 0x20) != 0;
-            break;
         }
 
         if((paletteIndex & 0x03) != 0) {

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -1126,6 +1126,19 @@ yyy NN YYYYY XXXXX
             case 0: readPpuMemory(getNameTableAddr()); break;
             case 2: readPpuMemory(getAttributeTableAddr()); break;
             case 4:
+                // Preserve the old approximate A12 behavior used by MMC3 IRQ timing.
+                {
+                    bool a12High = false;
+                    if(m_spriteSize8x16) {
+                        a12High = (sprite->indexInPatternTable & 0x01) != 0;
+                    }
+                    else {
+                        a12High = m_sprite8x8PatternTableAddress;
+                    }
+                    setBusAddress(static_cast<uint16_t>(m_busAddress | (a12High ? 0x1000 : 0x0000)));
+                    m_cartridge.setA12State(a12High);
+                }
+
                 if(!hasSpriteData || sprite->y == 0xFF) {
                     entry.lowByte = 0;
                     readPpuMemory(0);

--- a/src/GeraNES/PPU.h
+++ b/src/GeraNES/PPU.h
@@ -207,7 +207,6 @@ private:
     GERANES_HOT auto readWritePpuMemory(uint16_t addr, uint8_t data = 0) -> std::conditional_t<writeFlag, void, uint8_t>
     {
         m_currentReadAffectsBus = affectsTheBus;
-        m_cartridge.setPpuReadAffectsBus(affectsTheBus);
 
         if constexpr(!writeFlag && affectsTheBus) {
             m_cartridge.onPpuRead(addr & 0x3FFF);

--- a/src/GeraNES/defines.h
+++ b/src/GeraNES/defines.h
@@ -20,7 +20,7 @@
 #include <string>
 
 static constexpr std::string GERANES_NAME = "GeraNES";
-static constexpr std::string GERANES_VERSION = "1.6.1";
+static constexpr std::string GERANES_VERSION = "1.6.2";
 
 static constexpr uint32_t SAVE_STATE_MAGIC = makeMagic('G','N','E','S');
 static constexpr uint32_t SAVE_STATE_VERSION = 0;

--- a/src/GeraNESApp/AudioOutputBase.h
+++ b/src/GeraNESApp/AudioOutputBase.h
@@ -16,6 +16,7 @@ private:
 
     SampleWave m_sample;
     SampleDirect m_sampleDirect;
+    SampleWave m_expansionSample;
 
     FirstOrderHighPassFilter m_hpFilter1;
     FirstOrderHighPassFilter m_hpFilter2;
@@ -39,6 +40,7 @@ public:
         m_noise.init(sampleRate);
         m_sample.init(sampleRate);
         m_sampleDirect.init(sampleRate);
+        m_expansionSample.init(sampleRate);
 
         //from https://www.nesdev.org/wiki/APU_Mixer
         m_hpFilter1.init(sampleRate, 90);
@@ -49,14 +51,15 @@ public:
     void clearBuffers()
     {
         m_sampleDirect.clearBuffer();
-        m_sample.clearBuffer();   
+        m_sample.clearBuffer();
+        m_expansionSample.clearBuffer();
     }
 
     GERANES_INLINE_HOT float mix()
     {
         float ret = 0;
 
-        const float sum = 0.5f+0.5f+0.5f+1.0f+1.5f+1.5f;
+        const float sum = 0.5f+0.5f+0.5f+1.0f+1.5f+1.5f+1.0f;
 
         //empirical values 
         ret += 0.5f/sum*m_pulseWave1.get();
@@ -65,6 +68,7 @@ public:
         ret += 1.0f/sum*m_noise.get();
         ret += 1.5f/sum*m_sample.get();
         ret += 1.5f/sum*m_sampleDirect.get();
+        ret += 1.0f/sum*m_expansionSample.get();
 
         ret = m_hpFilter1.apply(ret);
         ret = m_hpFilter2.apply(ret);
@@ -118,6 +122,23 @@ public:
     void addSampleDirect(float period, float sample) override
     {
         m_sampleDirect.add(period,sample);
+    }
+
+    void setExpansionAudioSampleRate(float rateHz) override
+    {
+        if(rateHz > 1.0f) {
+            m_expansionSample.setFrequency(rateHz);
+        }
+    }
+
+    void setExpansionAudioVolume(float volume) override
+    {
+        m_expansionSample.setVolume(volume);
+    }
+
+    void addExpansionAudioSample(float sample) override
+    {
+        m_expansionSample.add(sample);
     }
 
 };

--- a/src/GeraNESApp/SDLAudioOutput.h
+++ b/src/GeraNESApp/SDLAudioOutput.h
@@ -113,32 +113,44 @@ public:
 
         if(deviceName == "") {
 
-            char* name;
+            char* name = nullptr;
             SDL_AudioSpec dummySpec;
             if(SDL_GetDefaultAudioInfo(&name, &dummySpec, 0) != 0) {
-                Logger::instance().log("SDL_GetDefaultAudioInfo error", Logger::Type::ERROR);
-                return false;
+                Logger::instance().log(std::string("SDL_GetDefaultAudioInfo error: ") + SDL_GetError(), Logger::Type::WARNING);
+                _deviceName = "";
             }
-            _deviceName = name;
-            SDL_free(name); 
+            else {
+                _deviceName = name ? name : "";
+            }
+            if(name) SDL_free(name);
         }
 
-        int deviceIndex = 0;
+        int deviceIndex = -1;
 
         auto deviceList = getAudioList();
 
-        for(int i = 0; i < deviceList.size(); i++) {
+        for(int i = 0; i < static_cast<int>(deviceList.size()); i++) {
             if(_deviceName == deviceList[i]) {
                 deviceIndex = i;
                 break;
             }
         }
 
-        SDL_AudioSpec preferedSpec;
+        if(!_deviceName.empty() && deviceIndex < 0) {
+            Logger::instance().log(std::string("Requested audio device not found: ") + _deviceName + ". Falling back to SDL default.", Logger::Type::WARNING);
+            _deviceName = "";
+        }
 
-        if( SDL_GetAudioDeviceSpec(deviceIndex, 0, &preferedSpec) != 0) {
-            Logger::instance().log("SDL_GetAudioDeviceSpec error", Logger::Type::ERROR);
-            return false;
+        SDL_AudioSpec preferedSpec{};
+        preferedSpec.freq = 44100;
+        preferedSpec.format = AUDIO_S16;
+        preferedSpec.channels = 1;
+
+        if(deviceIndex >= 0 && SDL_GetAudioDeviceSpec(deviceIndex, 0, &preferedSpec) != 0) {
+            Logger::instance().log(std::string("SDL_GetAudioDeviceSpec error: ") + SDL_GetError() + ". Using fallback format.", Logger::Type::WARNING);
+            preferedSpec.freq = 44100;
+            preferedSpec.format = AUDIO_S16;
+            preferedSpec.channels = 1;
         }
 
         m_currentDeviceName = _deviceName;
@@ -154,7 +166,7 @@ public:
     
         spec.freq = sampleRate;
         spec.channels = 1;
-        spec.samples = sampleRate*BUFFER_TIME;
+        spec.samples = static_cast<uint16_t>(sampleRate*BUFFER_TIME);
         spec.callback = nullptr;
         spec.userdata = this;
 
@@ -174,15 +186,18 @@ public:
 
         m_device = SDL_OpenAudioDevice(_deviceName != "" ? _deviceName.c_str() : nullptr, 0, &spec, &obtained, 0);
 
-        if(m_device == 0 || spec.format != obtained.format) {
+        if(m_device == 0) {
             turnOff();
-            Logger::instance().log("Audio init error", Logger::Type::ERROR);
+            Logger::instance().log(std::string("Audio init error: ") + SDL_GetError(), Logger::Type::ERROR);
             return false; 
         }
 
-        Logger::instance().log(std::string("Audio device: ") + _deviceName, Logger::Type::INFO);
-        Logger::instance().log(std::string("Sample rate: ") + std::to_string(sampleRate), Logger::Type::INFO); 
-        Logger::instance().log(std::string("Sample size: ") + std::to_string(sampleSize), Logger::Type::INFO); 
+        spec = obtained;
+        m_currentDeviceName = _deviceName.empty() ? "default" : _deviceName;
+
+        Logger::instance().log(std::string("Audio device: ") + m_currentDeviceName, Logger::Type::INFO);
+        Logger::instance().log(std::string("Sample rate: ") + std::to_string(spec.freq), Logger::Type::INFO); 
+        Logger::instance().log(std::string("Sample size: ") + std::to_string(spec.format & 0xFF), Logger::Type::INFO); 
 
         SDL_PauseAudioDevice(m_device, 0);
 


### PR DESCRIPTION
This PR rewrites MMC5 behavior to more closely match hardware timing and banking and fixes major rendering issues seen in MMC5 games (e.g., BG/sprite mapping issues and missing text paths).

It also adds MMC5 expansion audio support (2 pulse channels + PCM DAC).

## What was changed

### 1) Core MMC5 mapper correctness overhaul

- Reworked `Mapper005` behavior to better match documented hardware behavior.
- Fixed PRG/CHR mapping interactions and mode handling.
- Corrected `$5101` behavior:
  - CHR mode decode
  - CHR ROM/RAM mode bit handling
  - Dynamic mask selection for ROM vs RAM CHR space
- Fixed CHR A/B bank source selection rules, including last-written A/B behavior and rendering-time source selection.
- Fixed ExRAM mode behavior and write gating (`$5C00-$5FFF`) based on in-frame/render state.
- Fixed split-screen and extended attribute nametable substitution behavior.
- Improved split attribute expansion and ExRAM attribute decoding path.
- Corrected `PPUMASK` / frame-state interactions that were incorrectly resetting MMC5 internal state.
- Removed incorrect CPU-vector-based frame reset behavior in mapper runtime path.

### 2) Mapper / PPU integration and timing plumbing

- Added per-PPU-cycle mapper callback hook:
  - `BaseMapper::onPpuCycle(...)`
  - Forwarded through `Cartridge`
  - Invoked from PPU each cycle
- Ensured mapper receives correct BG vs sprite fetch-source context during PPU fetches.
- Kept mapper state serialization aligned with new runtime state fields.

### 3) MMC5 expansion audio implementation

- Implemented MMC5 audio registers and runtime synthesis in `Mapper005`:
  - Pulse channels: `$5000-$5007`
  - Channel enable / length status: `$5015`
  - PCM DAC latch/value path: `$5011` (with control register state)
- Added per-CPU-cycle MMC5 audio stepping in `mapper.cycle()`.
- Added mapper expansion-audio sample output hook:
  - `BaseMapper::getExpansionAudioSample()`
  - Forwarded by `Cartridge`
  - Consumed from CPU cycle path into the audio pipeline
- Extended audio interface / mixer to accept and mix expansion audio stream:
  - New expansion sample-rate / volume / sample methods on the audio output interface
  - Dedicated expansion sample channel mixed into final output.

## Main files touched

- `src/GeraNES/Mappers/Mapper005.h`
- `src/GeraNES/Mappers/BaseMapper.h`
- `src/GeraNES/Cartridge.h`
- `src/GeraNES/PPU.h`
- `src/GeraNES/CPU2A03.h`
- `src/GeraNES/APU/APU.h`
- `src/GeraNES/IAudioOutput.h`
- `src/GeraNESApp/AudioOutputBase.h`